### PR TITLE
feat : Implement Text FIeld Composables for Password and Email

### DIFF
--- a/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
@@ -1,2 +1,121 @@
 package com.tpc.nudj.ui.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun EmailField(
+    modifier: Modifier = Modifier,
+    email: String = "",
+    onEmailChange: (String) -> Unit
+
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 44.dp)
+    ) {
+        Text(
+            text = "Email",
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(bottom = 2.dp),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W400,
+            color = Color(0xFFFF5E00)
+        )
+        OutlinedTextField(
+            value = email,
+            onValueChange = onEmailChange,
+            modifier = modifier
+                .border(width = 1.8F.dp, color = Color(0xFF3F1872),shape = RoundedCornerShape(16.dp))
+                .background(Color(0xFFFF5E00).copy(alpha = 0.1f), shape = RoundedCornerShape(24.dp))
+                .fillMaxWidth()
+                .height(60.dp),
+            textStyle = androidx.compose.ui.text.TextStyle(fontSize = 20.sp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = Color.Transparent,
+                unfocusedBorderColor = Color.Transparent
+            )
+        )
+    }
+}
+
+@Composable
+fun PasswordField(
+    modifier: Modifier = Modifier,
+    password: String = "",
+    onPasswordChange: (String) -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 44.dp)
+    ) {
+        Text(
+            text = "Password",
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(bottom = 2.dp),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W400,
+            color = Color(0xFFFF5E00)
+        )
+        OutlinedTextField(
+            value = password,
+            onValueChange = onPasswordChange,
+            modifier = modifier
+                .border(width = 1.8F.dp, color = Color(0xFF3F1872),shape = RoundedCornerShape(16.dp))
+                .background(Color(0xFFFF5E00).copy(alpha = 0.1f), shape = RoundedCornerShape(24.dp))
+                .fillMaxWidth()
+                .height(60.dp),
+            textStyle = androidx.compose.ui.text.TextStyle(fontSize = 28.sp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = Color.Transparent,
+                unfocusedBorderColor = Color.Transparent
+            ),
+            visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation()
+        )
+    }
+}
+
+
+@Preview(
+    name = "EmailFieldPreview",
+    showBackground = true
+)
+@Composable
+fun EmailFieldPreview() {
+    var email by remember { mutableStateOf("") }
+    EmailField(email = email, onEmailChange = { email = it })
+}
+
+@Preview(
+    name = "PasswordFieldPreview",
+    showBackground = true
+)
+@Composable
+fun PasswordFieldPreview() {
+    var password by remember { mutableStateOf("") }
+    PasswordField(password = password, onPasswordChange = { password = it })
+}

--- a/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.tpc.nudj.ui.theme.ClashDisplay
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.ui.theme.NudjTheme
 
 @Composable
 fun EmailField(
@@ -30,6 +33,8 @@ fun EmailField(
     onEmailChange: (String) -> Unit
 
 ) {
+    val colors = LocalAppColors.current
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -38,21 +43,20 @@ fun EmailField(
         Text(
             text = "Email",
             modifier = Modifier
-                .align(Alignment.Start)
-                .padding(bottom = 2.dp),
+                .align(Alignment.Start),
             fontSize = 18.sp,
-            fontWeight = FontWeight.W400,
-            color = Color(0xFFFF5E00)
+            fontFamily = ClashDisplay,
+            color = colors.viewText
         )
         OutlinedTextField(
             value = email,
             onValueChange = onEmailChange,
             modifier = modifier
-                .border(width = 1.8F.dp, color = Color(0xFF3F1872),shape = RoundedCornerShape(16.dp))
-                .background(Color(0xFFFF5E00).copy(alpha = 0.1f), shape = RoundedCornerShape(24.dp))
+                .border(width = 1.8F.dp, color = colors.editTextBorder,shape = RoundedCornerShape(16.dp))
+                .background(colors.editTextBackground, shape = RoundedCornerShape(24.dp))
                 .fillMaxWidth()
                 .height(60.dp),
-            textStyle = androidx.compose.ui.text.TextStyle(fontSize = 20.sp),
+            textStyle = androidx.compose.ui.text.TextStyle(fontSize = 20.sp, fontFamily = ClashDisplay),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = Color.Transparent,
                 unfocusedBorderColor = Color.Transparent
@@ -67,6 +71,7 @@ fun PasswordField(
     password: String = "",
     onPasswordChange: (String) -> Unit
 ) {
+    val colors = LocalAppColors.current
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -75,21 +80,21 @@ fun PasswordField(
         Text(
             text = "Password",
             modifier = Modifier
-                .align(Alignment.Start)
-                .padding(bottom = 2.dp),
+                .align(Alignment.Start) ,
             fontSize = 18.sp,
             fontWeight = FontWeight.W400,
-            color = Color(0xFFFF5E00)
+            fontFamily = ClashDisplay,
+            color = colors.viewText
         )
         OutlinedTextField(
             value = password,
             onValueChange = onPasswordChange,
             modifier = modifier
-                .border(width = 1.8F.dp, color = Color(0xFF3F1872),shape = RoundedCornerShape(16.dp))
-                .background(Color(0xFFFF5E00).copy(alpha = 0.1f), shape = RoundedCornerShape(24.dp))
+                .border(width = 1.8F.dp, colors.editTextBorder,shape = RoundedCornerShape(16.dp))
+                .background(colors.editTextBackground, shape = RoundedCornerShape(24.dp))
                 .fillMaxWidth()
                 .height(60.dp),
-            textStyle = androidx.compose.ui.text.TextStyle(fontSize = 28.sp),
+            textStyle = androidx.compose.ui.text.TextStyle(fontSize = 28.sp,fontFamily = ClashDisplay),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = Color.Transparent,
                 unfocusedBorderColor = Color.Transparent
@@ -101,21 +106,37 @@ fun PasswordField(
 
 
 @Preview(
-    name = "EmailFieldPreview",
+    name = "EmailFieldPreview-LightTheme",
     showBackground = true
+)
+@Preview(
+    name = "EmailFieldPreview-DarkTheme",
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF3F1872
 )
 @Composable
 fun EmailFieldPreview() {
-    var email by remember { mutableStateOf("") }
-    EmailField(email = email, onEmailChange = { email = it })
+    NudjTheme {
+        var email by remember { mutableStateOf("") }
+        EmailField(email = email, onEmailChange = { email = it })
+    }
 }
 
 @Preview(
-    name = "PasswordFieldPreview",
+    name = "PasswordFieldPreview-LightTheme",
     showBackground = true
+)
+@Preview(
+    name = "PasswordFieldPreview-DarkTheme",
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF3F1872
 )
 @Composable
 fun PasswordFieldPreview() {
-    var password by remember { mutableStateOf("") }
-    PasswordField(password = password, onPasswordChange = { password = it })
+    NudjTheme {
+        var password by remember { mutableStateOf("") }
+        PasswordField(password = password, onPasswordChange = { password = it })
+    }
 }

--- a/app/src/main/java/com/tpc/nudj/ui/theme/Color.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/theme/Color.kt
@@ -4,4 +4,5 @@ import androidx.compose.ui.graphics.Color
 
 val Purple = Color(0xFF3F1872)
 val Orange = Color(0xFFFF5E00)
+val EditTextBackgroundColorLight = Color(0xFFFFF1E6)
 val EditTextBackgroundColorDark = Color(0xFF691AD0)

--- a/app/src/main/java/com/tpc/nudj/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/theme/Theme.kt
@@ -52,7 +52,7 @@ private val LightColorScheme = AppColors(
     viewText = Orange,
     editText = Color.Black,
     editTextBorder = Purple,
-    editTextBackground = Color.White,
+    editTextBackground = EditTextBackgroundColorLight,
     fillButtonBackground = Orange,
 
     forgetPasswordText = Color.Black,


### PR DESCRIPTION
Implements text fields composables for password and email.

Used Shapes and typography as per the figma design. Colors are hardcoded for now.

# Pull Request – Nudj Contribution

## 🔧 What does this PR do?

Adds text field Composable functions for Password and Email fields

---

## 🧩 Related Issue

Closes: #1 

---

## 📸 Screenshots / UI Demo (If applicable)

![image](https://github.com/user-attachments/assets/0b09cb2a-489d-48ea-beec-6d27754a724d)

[text-fields-implementation.webm](https://github.com/user-attachments/assets/fa7f620f-46ea-443e-8022-35efdf4c943e)



---

## ✅ Checklist

- [x] My code follows the project's style and structure
- [x] I’ve tested my changes locally
- [x] I’ve not committed any files directly to `main`
- [x] I’ve commented my approach in the linked issue
- [x] My commit messages are clean and meaningful
- [x] This PR focuses on one clear task/feature only

---

## 🧠 Brief Explanation of Approach

The composable functions consist of a `Column` with children - `Text` and `OutlinedTextField`. I have implemented the text fields as per the Figma design.

---

## 📢 Additional Notes (Optional)

The colors are hardcoded for now. I would like some help in implementing the color schemes defined in `Theme.kt`.

---

