### PR TITLE
Implement loginScreen and ForgetPasswordScreen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name="com.tpc.nudj.application.NudjApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/tpc/nudj/MainActivity.kt
+++ b/app/src/main/java/com/tpc/nudj/MainActivity.kt
@@ -4,21 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.tpc.nudj.ui.navigation.ScreenRoute
 import com.tpc.nudj.ui.screen.DemoScreen
-import com.tpc.nudj.ui.screen.auth.forgotPassword.ForgetPasswordScreen
-import com.tpc.nudj.ui.screen.auth.login.LoginScreen
-import com.tpc.nudj.ui.screen.auth.login.LoginScreenLayout
-import com.tpc.nudj.ui.screen.auth.login.LoginUiState
 import com.tpc.nudj.ui.theme.NudjTheme
 import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
@@ -37,7 +27,9 @@ class MainActivity : ComponentActivity() {
                             DemoScreen()
                         }
                     }
+
                 )
+
             }
         }
     }

--- a/app/src/main/java/com/tpc/nudj/MainActivity.kt
+++ b/app/src/main/java/com/tpc/nudj/MainActivity.kt
@@ -4,12 +4,24 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.tpc.nudj.ui.navigation.ScreenRoute
 import com.tpc.nudj.ui.screen.DemoScreen
+import com.tpc.nudj.ui.screen.auth.forgotPassword.ForgetPasswordScreen
+import com.tpc.nudj.ui.screen.auth.login.LoginScreen
+import com.tpc.nudj.ui.screen.auth.login.LoginScreenLayout
+import com.tpc.nudj.ui.screen.auth.login.LoginUiState
 import com.tpc.nudj.ui.theme.NudjTheme
+import dagger.hilt.android.AndroidEntryPoint
+@AndroidEntryPoint
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
@@ -124,7 +124,7 @@ fun TertiaryButton(
                 textDecoration = TextDecoration.Underline
             ),
             textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 16.dp)
+            modifier = Modifier
         )
     }
 }

--- a/app/src/main/java/com/tpc/nudj/ui/components/LoadingIndicator.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/LoadingIndicator.kt
@@ -1,0 +1,32 @@
+package com.tpc.nudj.ui.components
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+@Composable
+fun LoadingIndicator(
+    isLoading: Boolean,
+    screen: @Composable () -> Unit
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        screen()
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.White.copy(alpha = 0.4f))
+            )
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/components/NudjTopAppBar.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/NudjTopAppBar.kt
@@ -1,0 +1,49 @@
+package com.tpc.nudj.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tpc.nudj.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NudjTopAppBar(
+    onBackClick: () -> Unit
+) {
+    CenterAlignedTopAppBar(
+        title = {
+            Text(
+                text ="NUDJ",
+                fontWeight = FontWeight.Bold
+
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onBackClick) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+            }
+        }
+    )
+}
+@Preview(showBackground = true)
+@Composable
+fun NudjTopAppBarPreview() {
+    NudjTopAppBar(
+        onBackClick = { }
+    )
+}

--- a/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
@@ -72,12 +72,14 @@ fun NudjTextField(
 }
 
 @Composable
-fun EmailTextField(value: String, onValueChange: (String) -> Unit) {
+fun EmailTextField(value: String, onValueChange: (String) -> Unit,
+                   placeholder: String = "") {
     NudjTextField(
         value = value,
         onValueChange = onValueChange,
         label = "Email",
-        keyboardType = KeyboardType.Email
+        keyboardType = KeyboardType.Email,
+        placeholder = placeholder,
     )
 }
 
@@ -86,12 +88,14 @@ fun PasswordTextField(
     value: String,
     onValueChange: (String) -> Unit,
     passwordVisible: Boolean,
-    onPasswordVisibilityToggle: () -> Unit
+    onPasswordVisibilityToggle: () -> Unit,
+    placeholder: String = ""
 ) {
     NudjTextField(
         value = value,
         onValueChange = onValueChange,
         label = "Password",
+        placeholder = placeholder,
         isPassword = !passwordVisible,
         keyboardType = KeyboardType.Password,
         trailingIcon = {

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tpc.nudj.ui.components.EmailTextField
+import com.tpc.nudj.ui.components.LoadingIndicator
 import com.tpc.nudj.ui.components.NudjTopAppBar
 import com.tpc.nudj.ui.components.PrimaryButton
 import com.tpc.nudj.ui.screen.auth.login.LoginScreenLayout
@@ -39,13 +40,16 @@ fun ForgetPasswordScreen(
         }
     ) { paddingValues ->
         val uiState by viewModel.forgotPasswordUiState.collectAsState()
-        ForgetPasswordScreenLayout(
-            modifier = Modifier.padding(paddingValues),
-            uiState = uiState,
-            onEmailInput = viewModel::onEmailChange,
-            onSendEmailClick = viewModel ::onSendEmailClick
+        LoadingIndicator(isLoading = uiState.isLoading) {
 
-        )
+            ForgetPasswordScreenLayout(
+                modifier = Modifier.padding(paddingValues),
+                uiState = uiState,
+                onEmailInput = viewModel::onEmailChange,
+                onSendEmailClick = viewModel::onSendEmailClick
+
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
@@ -1,2 +1,92 @@
 package com.tpc.nudj.ui.screen.auth.forgotPassword
 
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.tpc.nudj.ui.components.EmailTextField
+import com.tpc.nudj.ui.components.NudjTopAppBar
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.screen.auth.login.LoginScreenLayout
+import com.tpc.nudj.ui.screen.auth.login.LoginUiState
+import com.tpc.nudj.viewmodels.auth.forgotPassword.ForgotPasswordViewModel
+
+@Composable
+fun ForgetPasswordScreen(
+    viewModel: ForgotPasswordViewModel = hiltViewModel(),
+    onSendEmailClick :()-> Unit ={}
+) {
+    Scaffold(
+        topBar = {
+            NudjTopAppBar(
+                onBackClick = {}
+            )
+        }
+    ) { paddingValues ->
+        val uiState by viewModel.forgotPasswordUiState.collectAsState()
+        ForgetPasswordScreenLayout(
+            modifier = Modifier.padding(paddingValues),
+            uiState = uiState,
+            onEmailInput = viewModel::onEmailChange,
+            onSendEmailClick = onSendEmailClick
+
+        )
+    }
+}
+
+@Composable
+fun ForgetPasswordScreenLayout(
+    modifier: Modifier = Modifier,
+    uiState: ForgotPasswordUiState,
+    onEmailInput : (String) -> Unit,
+    onSendEmailClick: () -> Unit
+
+){
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+
+    ){
+        Spacer(modifier = Modifier.height(160.dp))
+        EmailTextField(
+            value = uiState.email,
+            onValueChange = onEmailInput
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        PrimaryButton(
+            text = "Send Email",
+            onClick = onSendEmailClick,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ForgetPasswordScreenLayoutPreview() {
+    ForgetPasswordScreenLayout(
+        modifier = Modifier,
+        uiState = ForgotPasswordUiState(),
+        onEmailInput = {},
+        onSendEmailClick = {}
+    )
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
@@ -2,6 +2,7 @@ package com.tpc.nudj.ui.screen.auth.forgotPassword
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,7 +29,7 @@ import com.tpc.nudj.viewmodels.auth.forgotPassword.ForgotPasswordViewModel
 @Composable
 fun ForgetPasswordScreen(
     viewModel: ForgotPasswordViewModel = hiltViewModel(),
-    onSendEmailClick :()-> Unit ={}
+
 ) {
     Scaffold(
         topBar = {
@@ -42,7 +43,7 @@ fun ForgetPasswordScreen(
             modifier = Modifier.padding(paddingValues),
             uiState = uiState,
             onEmailInput = viewModel::onEmailChange,
-            onSendEmailClick = onSendEmailClick
+            onSendEmailClick = viewModel ::onSendEmailClick
 
         )
     }
@@ -60,14 +61,16 @@ fun ForgetPasswordScreenLayout(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(horizontal = 24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
 
     ){
-        Spacer(modifier = Modifier.height(160.dp))
+
         EmailTextField(
             value = uiState.email,
-            onValueChange = onEmailInput
+            onValueChange = onEmailInput,
+            placeholder = "Enter your email"
         )
         Spacer(modifier = Modifier.height(24.dp))
         PrimaryButton(

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgotPasswordUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgotPasswordUiState.kt
@@ -1,0 +1,9 @@
+package com.tpc.nudj.ui.screen.auth.forgotPassword
+
+data class ForgotPasswordUiState (
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val toastMessage: String? = null,
+    val email:String = ""
+
+)

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginScreen.kt
@@ -41,6 +41,7 @@ import com.tpc.nudj.viewmodels.auth.login.LoginViewModel
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.tpc.nudj.ui.components.LoadingIndicator
 import com.tpc.nudj.ui.components.NudjTopAppBar
 
 
@@ -57,22 +58,24 @@ fun LoginScreen(
             )
         }
     ) { paddingValues ->
-    val uiState by viewModel.loginUiState.collectAsState()
-    LoginScreenLayout(
-        modifier = Modifier.padding(paddingValues),
-        uiState = uiState,
-        onEmailInput = { email ->
-            viewModel.onEmailChange(email)
-        },
-        onPasswordInput = { pass ->
-            viewModel.onPasswordChange(pass)
-        },
-        onForgotPasswordClick = viewModel::onForgotPasswordClick,
-        onLoginClick = viewModel::onLoginClick,
-        onGoogleClick = viewModel::onGoogleClick,
-        onPasswordVisibilityToggle = viewModel::togglePasswordVisibility,
-    )
-}
+        val uiState by viewModel.loginUiState.collectAsState()
+        LoadingIndicator(isLoading = uiState.isLoading) {
+            LoginScreenLayout(
+                modifier = Modifier.padding(paddingValues),
+                uiState = uiState,
+                onEmailInput = { email ->
+                    viewModel.onEmailChange(email)
+                },
+                onPasswordInput = { pass ->
+                    viewModel.onPasswordChange(pass)
+                },
+                onForgotPasswordClick = viewModel::onForgotPasswordClick,
+                onLoginClick = viewModel::onLoginClick,
+                onGoogleClick = viewModel::onGoogleClick,
+                onPasswordVisibilityToggle = viewModel::togglePasswordVisibility,
+            )
+        }
+    }
 }
 @Composable
 fun LoginScreenLayout(

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginScreen.kt
@@ -1,59 +1,178 @@
 package com.tpc.nudj.ui.screen.auth.login
 
+import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import com.tpc.nudj.R
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.tpc.nudj.ui.components.EmailTextField
+import com.tpc.nudj.ui.components.PasswordTextField
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.components.TertiaryButton
 import com.tpc.nudj.ui.theme.NudjTheme
 import com.tpc.nudj.viewmodels.auth.login.LoginViewModel
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.tpc.nudj.ui.components.NudjTopAppBar
 
 
 @Composable
 fun LoginScreen(
-    viewmodel: LoginViewModel = hiltViewModel()
+    viewModel: LoginViewModel = hiltViewModel(),
+    onLoginClick: () -> Unit = {},
+    onForgotPasswordClick: () -> Unit = {},
+    onGoogleClick: () -> Unit ={}
+
 ) {
-    val uiState by viewmodel.loginUiState.collectAsState()
+    Scaffold(
+        topBar = {
+            NudjTopAppBar(
+                onBackClick = {}
+            )
+        }
+    ) { paddingValues ->
+    val uiState by viewModel.loginUiState.collectAsState()
     LoginScreenLayout(
+        modifier = Modifier.padding(paddingValues),
         uiState = uiState,
         onEmailInput = { email ->
-            viewmodel.onEmailChange(email)
+            viewModel.onEmailChange(email)
         },
         onPasswordInput = { pass ->
-            viewmodel.onPasswordChange(pass)
+            viewModel.onPasswordChange(pass)
         },
-        onForgotPasswordClick = { /* Handle the forgot password click here */ },
-        onLoginClick = { /* Handle the login click here */ },
-        onGoogleClick = { /* Handle the Google sign-in here */ }
+        onForgotPasswordClick = onForgotPasswordClick,
+        onLoginClick = onLoginClick,
+        onGoogleClick = onGoogleClick
     )
 }
-
+}
 @Composable
 fun LoginScreenLayout(
-    uiState: LoginUiState,
+    modifier: Modifier = Modifier,
+    uiState :LoginUiState,
     onEmailInput: (String) -> Unit,
     onPasswordInput: (String) -> Unit,
     onForgotPasswordClick: () -> Unit,
     onLoginClick: () -> Unit,
     onGoogleClick: () -> Unit,
 ) {
-    // Code the layout for login screen here with the ref design provided
-}
-
-
-@Preview(showBackground = true)
-@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
-@Composable
-fun PreviewLoginScreen() {
-    NudjTheme {
-        LoginScreenLayout(
-            uiState = LoginUiState(),
-            onEmailInput = {},
-            onPasswordInput = {},
-            onForgotPasswordClick = {},
-            onLoginClick = {},
-            onGoogleClick = {}
-        )
+    var passwordVisible by remember {
+        mutableStateOf(false)
     }
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(140.dp))
+        EmailTextField(
+            value = uiState.email,
+            onValueChange = onEmailInput
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        PasswordTextField(
+            value = uiState.password,
+            onValueChange = onPasswordInput,
+            passwordVisible = passwordVisible,
+            onPasswordVisibilityToggle = {
+                passwordVisible = !passwordVisible
+            }
+        )
+            TertiaryButton(
+                text = "Forgot Password?",
+                onClick = onForgotPasswordClick,
+                modifier = Modifier.align(Alignment.Start)
+
+
+            )
+
+
+        Spacer(modifier = Modifier.height(24.dp))
+        PrimaryButton(
+            text = "Login",
+            onClick = onLoginClick,
+            enabled = !uiState.isLoading,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            HorizontalDivider(
+                modifier = Modifier.weight(1f)
+            )
+
+            Text(
+                text = "OR",
+                modifier = Modifier.padding(horizontal = 16.dp),
+                fontWeight = FontWeight.Bold,
+                fontSize = 20.sp
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Image(
+            painter = painterResource(id = R.drawable.google),
+            contentDescription = "Google Sign In",
+            modifier = Modifier
+                .size(50.dp)
+                .clickable(onClick = onGoogleClick)
+        )
+
+
+
+    }
+
+    }
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LoginScreenLayoutPreview() {
+    LoginScreenLayout(
+        modifier = Modifier,
+        uiState = LoginUiState(),
+        onEmailInput = {},
+        onPasswordInput = {},
+        onForgotPasswordClick = {},
+        onLoginClick = {},
+        onGoogleClick = {}
+    )
 }
+
+

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginScreen.kt
@@ -5,6 +5,7 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -46,9 +47,7 @@ import com.tpc.nudj.ui.components.NudjTopAppBar
 @Composable
 fun LoginScreen(
     viewModel: LoginViewModel = hiltViewModel(),
-    onLoginClick: () -> Unit = {},
-    onForgotPasswordClick: () -> Unit = {},
-    onGoogleClick: () -> Unit ={}
+
 
 ) {
     Scaffold(
@@ -68,46 +67,46 @@ fun LoginScreen(
         onPasswordInput = { pass ->
             viewModel.onPasswordChange(pass)
         },
-        onForgotPasswordClick = onForgotPasswordClick,
-        onLoginClick = onLoginClick,
-        onGoogleClick = onGoogleClick
+        onForgotPasswordClick = viewModel::onForgotPasswordClick,
+        onLoginClick = viewModel::onLoginClick,
+        onGoogleClick = viewModel::onGoogleClick,
+        onPasswordVisibilityToggle = viewModel::togglePasswordVisibility,
     )
 }
 }
 @Composable
 fun LoginScreenLayout(
+    uiState: LoginUiState,
     modifier: Modifier = Modifier,
-    uiState :LoginUiState,
     onEmailInput: (String) -> Unit,
     onPasswordInput: (String) -> Unit,
+    onPasswordVisibilityToggle: () -> Unit,
     onForgotPasswordClick: () -> Unit,
     onLoginClick: () -> Unit,
-    onGoogleClick: () -> Unit,
+    onGoogleClick: () -> Unit
 ) {
-    var passwordVisible by remember {
-        mutableStateOf(false)
-    }
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .padding(horizontal = 24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        Spacer(modifier = Modifier.height(140.dp))
+
         EmailTextField(
             value = uiState.email,
-            onValueChange = onEmailInput
+            onValueChange = onEmailInput,
+            placeholder= "Enter your email"
         )
         Spacer(modifier = Modifier.height(16.dp))
 
         PasswordTextField(
             value = uiState.password,
             onValueChange = onPasswordInput,
-            passwordVisible = passwordVisible,
-            onPasswordVisibilityToggle = {
-                passwordVisible = !passwordVisible
-            }
+            passwordVisible = uiState.passwordVisible,
+            placeholder = "Enter your password",
+            onPasswordVisibilityToggle = onPasswordVisibilityToggle
         )
             TertiaryButton(
                 text = "Forgot Password?",
@@ -171,7 +170,8 @@ private fun LoginScreenLayoutPreview() {
         onPasswordInput = {},
         onForgotPasswordClick = {},
         onLoginClick = {},
-        onGoogleClick = {}
+        onGoogleClick = {},
+        onPasswordVisibilityToggle = {}
     )
 }
 

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/login/LoginUiState.kt
@@ -5,5 +5,6 @@ data class LoginUiState(
     val errorMessage: String? =null,
     val toastMessage:String?=null,
     val email:String = "",
-    val password:String = ""
+    val password:String = "",
+    val passwordVisible: Boolean = false
 )

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
@@ -21,4 +21,7 @@ class ForgotPasswordViewModel @Inject constructor() : ViewModel() {
             it.copy(email = email)
         }
     }
+    fun onSendEmailClick(){
+
+    }
 }

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
@@ -1,1 +1,24 @@
 package com.tpc.nudj.viewmodels.auth.forgotPassword
+
+import androidx.lifecycle.ViewModel
+import com.tpc.nudj.ui.screen.auth.forgotPassword.ForgotPasswordUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+@HiltViewModel
+class ForgotPasswordViewModel @Inject constructor() : ViewModel() {
+
+    private val _forgotPasswordUiState = MutableStateFlow(ForgotPasswordUiState())
+
+    val forgotPasswordUiState: StateFlow<ForgotPasswordUiState> = _forgotPasswordUiState.asStateFlow()
+
+    fun onEmailChange(email: String) {
+        _forgotPasswordUiState.update {
+            it.copy(email = email)
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/login/LoginViewModel.kt
@@ -34,7 +34,13 @@ class LoginViewModel @Inject constructor() : ViewModel() {
             )
         }
     }
-    fun onLoginClick() {}
+    fun onLoginClick() {
+        //        viewModelScope.launch {
+//            _loginUiState.update { it.copy(isLoading = true) }
+//            delay(2000)
+//            _loginUiState.update { it.copy(isLoading = false) }
+//        }
+    }
 
     fun onForgotPasswordClick() {}
 

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/login/LoginViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
@@ -14,10 +15,15 @@ class LoginViewModel @Inject constructor() : ViewModel() {
     val loginUiState: StateFlow<LoginUiState> = _loginUiState.asStateFlow()
 
     fun onEmailChange(email: String) {
-
+        _loginUiState.update {
+            it.copy(email = email)
+        }
     }
 
     fun onPasswordChange(password: String) {
+        _loginUiState.update {
+            it.copy(password = password)
+        }
 
     }
 

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/login/LoginViewModel.kt
@@ -25,6 +25,19 @@ class LoginViewModel @Inject constructor() : ViewModel() {
             it.copy(password = password)
         }
 
+
     }
+    fun togglePasswordVisibility() {
+        _loginUiState.update {
+            it.copy(
+                passwordVisible = !it.passwordVisible
+            )
+        }
+    }
+    fun onLoginClick() {}
+
+    fun onForgotPasswordClick() {}
+
+    fun onGoogleClick() {}
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
+
 pluginManagement {
     repositories {
         google {


### PR DESCRIPTION
# Pull Request – Nudj Contribution
Implement loginScreen and ForgetPasswordScreen

---

## 🔧 What does this PR do?
1.Implements the Login Screen UI using Jetpack Compose.
2.Implements the Forgot Password Screen UI using Jetpack Compose.
3.Adds LoginViewModel and ForgotPasswordViewModel for screen state management.
4. Adds reusable top app bar component for authentication screens.

---

## 🧩 Related Issue

Closes: #10 

---

## 📸 Screenshots / UI Demo (If applicable)

> Add screenshots or screen recordings to showcase any visual/UI changes.
<img width="720" height="1560" alt="Screenshot_20260610_173511" src="https://github.com/user-attachments/assets/b3ef602d-8bd8-44bf-bd74-cb8ef12ff9b7" />

https://github.com/user-attachments/assets/fa708917-0fd1-4100-87ba-ff03c3ebbb03


---

## ✅ Checklist

-  My code follows the project's style and structure
- I’ve tested my changes locally
- I’ve commented my approach in the linked issue
- My commit messages are clean and meaningful
- This PR focuses on one clear task/feature only

---

## 🧠 Brief Explanation of Approach

Implemented the Login and Forgot Password screens following a state hoisting approach. Screen state is maintained inside ViewModels exposed as immutable UI state. User interactions such as email input, password input, password visibility toggling, login action, and forgot password action are handled through callbacks passed to stateless composables. Hilt is used for ViewModel injection.

---

## 📢 Additional Notes (Optional)





---
