### PR TITLE
feat: email verification screen and finalize register UI

### DIFF
--- a/app/src/main/java/com/tpc/nudj/MainActivity.kt
+++ b/app/src/main/java/com/tpc/nudj/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.tpc.nudj.ui.navigation.ScreenRoute
 import com.tpc.nudj.ui.screen.DemoScreen
+import com.tpc.nudj.ui.screen.auth.register.RegisterScreen
 import com.tpc.nudj.ui.theme.NudjTheme
 import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
@@ -19,15 +20,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             NudjTheme {
-                val backStack = rememberNavBackStack(ScreenRoute.App.DemoScreen)
-                NavDisplay(
-                    backStack = backStack,
-                    entryProvider = entryProvider {
-                        entry<ScreenRoute.App.DemoScreen> {
-                            DemoScreen()
-                        }
-                    }
-
+                RegisterScreen(
+                    onNavigateBack = { finish() } // Ya jo bhi navigation logic ho
                 )
 
             }

--- a/app/src/main/java/com/tpc/nudj/MainActivity.kt
+++ b/app/src/main/java/com/tpc/nudj/MainActivity.kt
@@ -9,7 +9,6 @@ import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.tpc.nudj.ui.navigation.ScreenRoute
 import com.tpc.nudj.ui.screen.DemoScreen
-import com.tpc.nudj.ui.screen.auth.register.RegisterScreen
 import com.tpc.nudj.ui.theme.NudjTheme
 import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
@@ -20,8 +19,15 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             NudjTheme {
-                RegisterScreen(
-                    onNavigateBack = { finish() } // Ya jo bhi navigation logic ho
+                val backStack = rememberNavBackStack(ScreenRoute.App.DemoScreen)
+                NavDisplay(
+                    backStack = backStack,
+                    entryProvider = entryProvider {
+                        entry<ScreenRoute.App.DemoScreen> {
+                            DemoScreen()
+                        }
+                    }
+
                 )
 
             }

--- a/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
@@ -58,7 +58,7 @@ fun NudjTextField(
             shape = RoundedCornerShape(12.dp),
             leadingIcon = leadingIcon,
             trailingIcon = trailingIcon,
-            visualTransformation = if (isPassword) PasswordVisualTransformation(mask = '*') else VisualTransformation.None,
+            visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
             textStyle = MaterialTheme.typography.bodyLarge,
             colors = OutlinedTextFieldDefaults.colors(
@@ -86,6 +86,7 @@ fun EmailTextField(value: String, onValueChange: (String) -> Unit,
 @Composable
 fun PasswordTextField(
     value: String,
+    label: String = "password",
     onValueChange: (String) -> Unit,
     passwordVisible: Boolean,
     onPasswordVisibilityToggle: () -> Unit,
@@ -94,7 +95,7 @@ fun PasswordTextField(
     NudjTextField(
         value = value,
         onValueChange = onValueChange,
-        label = "Password",
+        label = label,
         placeholder = placeholder,
         isPassword = !passwordVisible,
         keyboardType = KeyboardType.Password,

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tpc.nudj.R
+import com.tpc.nudj.ui.components.LoadingIndicator
 import com.tpc.nudj.ui.components.NudjTopAppBar
 import com.tpc.nudj.ui.components.PrimaryButton
 import com.tpc.nudj.ui.components.TertiaryButton
@@ -28,12 +29,16 @@ fun EmailVerificationScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    EmailVerificationScreenLayout(
-        uiState = uiState,
-        onBackClick = onNavigateBack,
-        onCheckInboxClick = { viewModel.onCheckInboxClick() },
-        onResendEmailClick = { viewModel.onResendEmailClick() }
-    )
+    LoadingIndicator(
+        isLoading = uiState.isLoading
+    ) {
+        EmailVerificationScreenLayout(
+            uiState = uiState,
+            onBackClick = onNavigateBack,
+            onCheckInboxClick = { viewModel.onCheckInboxClick() },
+            onResendEmailClick = { viewModel.onResendEmailClick() }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
@@ -1,6 +1,8 @@
 package com.tpc.nudj.ui.screen.auth.emailVerification
 
+import android.content.Intent
 import android.content.res.Configuration
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -9,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,7 +38,6 @@ fun EmailVerificationScreen(
         EmailVerificationScreenLayout(
             uiState = uiState,
             onBackClick = onNavigateBack,
-            onCheckInboxClick = { viewModel.onCheckInboxClick() },
             onResendEmailClick = { viewModel.onResendEmailClick() }
         )
     }
@@ -45,9 +47,11 @@ fun EmailVerificationScreen(
 fun EmailVerificationScreenLayout(
     uiState: EmailVerificationUiState,
     onBackClick: () -> Unit,
-    onCheckInboxClick: () -> Unit,
     onResendEmailClick: () -> Unit
 ) {
+
+    val context = LocalContext.current
+
     Scaffold(
         topBar = {
             NudjTopAppBar(onBackClick = onBackClick)
@@ -81,18 +85,49 @@ fun EmailVerificationScreenLayout(
 
             PrimaryButton(
                 text = "Check Inbox",
-                onClick = onCheckInboxClick,
+                onClick = {
+                    val inboxIntent = Intent(Intent.ACTION_MAIN).apply {
+                        addCategory(Intent.CATEGORY_APP_EMAIL)
+                    }
+
+                    val chooser = Intent.createChooser(inboxIntent, "Open Inbox via Gmail")
+
+                    try {
+                        context.startActivity(chooser)
+                    } catch (e: Exception){
+                        Toast.makeText(
+                            context,
+                            "Error:Inbox Not Opened",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                },
                 modifier = Modifier
                     .padding(bottom = 16.dp)
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+
+            Spacer(modifier = Modifier.height(16.dp) )
 
             TertiaryButton(
                 text = "Resend Email?",
-                onClick = onResendEmailClick
+                onClick = onResendEmailClick,
+                enabled = uiState.isResendEnabled
             )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if(!uiState.isResendEnabled){
+                Text(
+                    text = "Resend in ${uiState.timerInSeconds}s",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+
         }
+
     }
 }
 
@@ -104,7 +139,6 @@ fun PreviewEmailVerificationScreen() {
         EmailVerificationScreenLayout(
             uiState = EmailVerificationUiState(),
             onBackClick = {},
-            onCheckInboxClick = {},
             onResendEmailClick = {}
         )
     }

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
@@ -1,2 +1,106 @@
 package com.tpc.nudj.ui.screen.auth.emailVerification
 
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tpc.nudj.R
+import com.tpc.nudj.ui.components.NudjTopAppBar
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.components.TertiaryButton
+import com.tpc.nudj.ui.theme.NudjTheme
+import com.tpc.nudj.viewmodels.auth.emailVerification.EmailVerificationViewModel
+
+@Composable
+fun EmailVerificationScreen(
+    viewModel: EmailVerificationViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    EmailVerificationScreenLayout(
+        uiState = uiState,
+        onBackClick = onNavigateBack,
+        onCheckInboxClick = { viewModel.onCheckInboxClick() },
+        onResendEmailClick = { viewModel.onResendEmailClick() }
+    )
+}
+
+@Composable
+fun EmailVerificationScreenLayout(
+    uiState: EmailVerificationUiState,
+    onBackClick: () -> Unit,
+    onCheckInboxClick: () -> Unit,
+    onResendEmailClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            NudjTopAppBar(onBackClick = onBackClick)
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = MaterialTheme.colorScheme.background)
+                .padding(paddingValues)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+
+            Text(
+                text = "Sent successfully!",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Image(
+                painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                contentDescription = "Email Sent Illustration",
+                modifier = Modifier.size(300.dp)
+            )
+
+            Spacer(modifier = Modifier.height(64.dp))
+
+            PrimaryButton(
+                text = "Check Inbox",
+                onClick = onCheckInboxClick,
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            TertiaryButton(
+                text = "Resend Email?",
+                onClick = onResendEmailClick
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PreviewEmailVerificationScreen() {
+    NudjTheme {
+        EmailVerificationScreenLayout(
+            uiState = EmailVerificationUiState(),
+            onBackClick = {},
+            onCheckInboxClick = {},
+            onResendEmailClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationScreen.kt
@@ -2,6 +2,7 @@ package com.tpc.nudj.ui.screen.auth.emailVerification
 
 import android.content.Intent
 import android.content.res.Configuration
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -9,6 +10,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -24,6 +28,7 @@ import com.tpc.nudj.ui.components.PrimaryButton
 import com.tpc.nudj.ui.components.TertiaryButton
 import com.tpc.nudj.ui.theme.NudjTheme
 import com.tpc.nudj.viewmodels.auth.emailVerification.EmailVerificationViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 fun EmailVerificationScreen(
@@ -51,10 +56,15 @@ fun EmailVerificationScreenLayout(
 ) {
 
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackBarHostState = remember { SnackbarHostState() }
 
     Scaffold(
         topBar = {
             NudjTopAppBar(onBackClick = onBackClick)
+        },
+        snackbarHost = {
+            SnackbarHost(hostState = snackBarHostState)
         }
     ) { paddingValues ->
         Column(
@@ -88,6 +98,7 @@ fun EmailVerificationScreenLayout(
                 onClick = {
                     val inboxIntent = Intent(Intent.ACTION_MAIN).apply {
                         addCategory(Intent.CATEGORY_APP_EMAIL)
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     }
 
                     val chooser = Intent.createChooser(inboxIntent, "Open Inbox via Gmail")
@@ -95,11 +106,9 @@ fun EmailVerificationScreenLayout(
                     try {
                         context.startActivity(chooser)
                     } catch (e: Exception){
-                        Toast.makeText(
-                            context,
-                            "Error:Inbox Not Opened",
-                            Toast.LENGTH_LONG
-                        ).show()
+                        scope.launch {
+                            snackBarHostState.showSnackbar("No Email app found")
+                        }
                     }
                 },
                 modifier = Modifier

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationUiState.kt
@@ -1,0 +1,5 @@
+package com.tpc.nudj.ui.screen.auth.emailVerification
+
+data class EmailVerificationUiState(
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationUiState.kt
@@ -1,5 +1,6 @@
 package com.tpc.nudj.ui.screen.auth.emailVerification
 
 data class EmailVerificationUiState(
+    val isLoading: Boolean = false,
     val errorMessage: String? = null
 )

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/emailVerification/EmailVerificationUiState.kt
@@ -2,5 +2,7 @@ package com.tpc.nudj.ui.screen.auth.emailVerification
 
 data class EmailVerificationUiState(
     val isLoading: Boolean = false,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val timerInSeconds: Int = 30,
+    val isResendEnabled: Boolean = true
 )

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterScreen.kt
@@ -3,6 +3,7 @@ package com.tpc.nudj.ui.screen.auth.register
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -20,7 +21,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tpc.nudj.R
+import com.tpc.nudj.model.AuthResult
 import com.tpc.nudj.ui.components.EmailTextField
+import com.tpc.nudj.ui.components.LoadingIndicator
 import com.tpc.nudj.ui.components.NudjTopAppBar
 import com.tpc.nudj.ui.components.PasswordTextField
 import com.tpc.nudj.ui.components.PrimaryButton
@@ -34,19 +37,23 @@ fun RegisterScreen(
 ) {
     val uiState by viewmodel.registerUiState.collectAsStateWithLifecycle()
 
-    RegisterScreenLayout(
-        uiState = uiState,
-        onEmailInput = { email -> viewmodel.onEmailChange(email) },
-        onPasswordInput = { pass -> viewmodel.onPasswordChange(pass) },
-        onConfirmPasswordInput = { pass -> viewmodel.onConfirmPasswordChange(pass) },
-        isPasswordVisible = uiState.isPasswordVisible,
-        isConfirmPasswordVisible = uiState.isConfirmPasswordVisible,
-        onPasswordVisibilityToggle = { viewmodel.onPasswordVisibilityToggle() },
-        onConfirmPasswordVisibilityToggle = { viewmodel.onConfirmPasswordVisibilityToggle() },
-        onSignUpClick = viewmodel::onRegisterClick,
-        onGoogleClick = viewmodel::onGoogleClick,
-        onBackClick = onNavigateBack
-    )
+    LoadingIndicator(
+        isLoading = uiState.isLoading
+    ) {
+        RegisterScreenLayout(
+            uiState = uiState,
+            onEmailInput = { email -> viewmodel.onEmailChange(email) },
+            onPasswordInput = { pass -> viewmodel.onPasswordChange(pass) },
+            onConfirmPasswordInput = { pass -> viewmodel.onConfirmPasswordChange(pass) },
+            isPasswordVisible = uiState.isPasswordVisible,
+            isConfirmPasswordVisible = uiState.isConfirmPasswordVisible,
+            onPasswordVisibilityToggle = { viewmodel.onPasswordVisibilityToggle() },
+            onConfirmPasswordVisibilityToggle = { viewmodel.onConfirmPasswordVisibilityToggle() },
+            onSignUpClick = viewmodel::onRegisterClick,
+            onGoogleClick = viewmodel::onGoogleClick,
+            onBackClick = onNavigateBack
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterScreen.kt
@@ -1,2 +1,147 @@
 package com.tpc.nudj.ui.screen.auth.register
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tpc.nudj.R
+import com.tpc.nudj.ui.components.EmailTextField
+import com.tpc.nudj.ui.components.NudjTopAppBar
+import com.tpc.nudj.ui.components.PasswordTextField
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.theme.NudjTheme
+import com.tpc.nudj.viewmodels.auth.register.RegisterViewModel
+
+@Composable
+fun RegisterScreen(
+    viewmodel: RegisterViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit
+) {
+    val uiState by viewmodel.registerUiState.collectAsStateWithLifecycle()
+
+    RegisterScreenLayout(
+        uiState = uiState,
+        onEmailInput = { email -> viewmodel.onEmailChange(email) },
+        onPasswordInput = { pass -> viewmodel.onPasswordChange(pass) },
+        onConfirmPasswordInput = { pass -> viewmodel.onConfirmPasswordChange(pass) },
+        onSignUpClick = {},
+        onGoogleClick =  {},
+        onBackClick = onNavigateBack
+    )
+}
+
+@Composable
+fun RegisterScreenLayout(
+    uiState: RegisterUiState,
+    onEmailInput: (String) -> Unit,
+    onPasswordInput: (String) -> Unit,
+    onConfirmPasswordInput: (String) -> Unit,
+    onSignUpClick: () -> Unit,
+    onGoogleClick: () -> Unit,
+    onBackClick: () -> Unit
+) {
+    var passwordVisible by rememberSaveable{ mutableStateOf(false) }
+    var confirmPasswordVisible by rememberSaveable { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            NudjTopAppBar(onBackClick = onBackClick)
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(paddingValues)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+
+
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                EmailTextField(
+                    value = uiState.email,
+                    onValueChange = onEmailInput
+                )
+
+                PasswordTextField(
+                    value = uiState.password,
+                    onValueChange = onPasswordInput,
+                    label = "Password",
+                    passwordVisible = passwordVisible,
+                    onPasswordVisibilityToggle = { passwordVisible = !passwordVisible }
+                )
+
+                PasswordTextField(
+                    value = uiState.confirmPassword,
+                    onValueChange = onConfirmPasswordInput,
+                    label = "Confirm Password",
+                    passwordVisible = confirmPasswordVisible,
+                    onPasswordVisibilityToggle = { confirmPasswordVisible = !confirmPasswordVisible }
+                )
+            }
+
+
+            Column(
+                modifier = Modifier.padding(top = 40.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                PrimaryButton(
+                    text = "Sign up",
+                    onClick = onSignUpClick,
+                    modifier = Modifier.padding(16.dp)
+                )
+
+                Text("OR", color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+
+                IconButton(
+                    onClick = onGoogleClick,
+                    modifier = Modifier.size(56.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.google),
+                        contentDescription = "Continue with Google",
+                        tint = Color.Unspecified
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun PreviewRegisterScreen() {
+    NudjTheme {
+        RegisterScreenLayout(
+            uiState = RegisterUiState(),
+            onEmailInput = {},
+            onPasswordInput = {},
+            onConfirmPasswordInput = {},
+            onSignUpClick = {},
+            onGoogleClick = {},
+            onBackClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterScreen.kt
@@ -10,9 +10,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tpc.nudj.R
 import com.tpc.nudj.ui.components.EmailTextField
 import com.tpc.nudj.ui.components.NudjTopAppBar
@@ -32,7 +30,7 @@ import com.tpc.nudj.viewmodels.auth.register.RegisterViewModel
 @Composable
 fun RegisterScreen(
     viewmodel: RegisterViewModel = hiltViewModel(),
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
 ) {
     val uiState by viewmodel.registerUiState.collectAsStateWithLifecycle()
 
@@ -41,8 +39,12 @@ fun RegisterScreen(
         onEmailInput = { email -> viewmodel.onEmailChange(email) },
         onPasswordInput = { pass -> viewmodel.onPasswordChange(pass) },
         onConfirmPasswordInput = { pass -> viewmodel.onConfirmPasswordChange(pass) },
-        onSignUpClick = {},
-        onGoogleClick =  {},
+        isPasswordVisible = uiState.isPasswordVisible,
+        isConfirmPasswordVisible = uiState.isConfirmPasswordVisible,
+        onPasswordVisibilityToggle = { viewmodel.onPasswordVisibilityToggle() },
+        onConfirmPasswordVisibilityToggle = { viewmodel.onConfirmPasswordVisibilityToggle() },
+        onSignUpClick = viewmodel::onRegisterClick,
+        onGoogleClick = viewmodel::onGoogleClick,
         onBackClick = onNavigateBack
     )
 }
@@ -53,12 +55,14 @@ fun RegisterScreenLayout(
     onEmailInput: (String) -> Unit,
     onPasswordInput: (String) -> Unit,
     onConfirmPasswordInput: (String) -> Unit,
+    onPasswordVisibilityToggle: () -> Unit,
+    onConfirmPasswordVisibilityToggle: () -> Unit,
+    isPasswordVisible : Boolean,
+    isConfirmPasswordVisible: Boolean,
     onSignUpClick: () -> Unit,
     onGoogleClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    var passwordVisible by rememberSaveable{ mutableStateOf(false) }
-    var confirmPasswordVisible by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -79,23 +83,26 @@ fun RegisterScreenLayout(
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 EmailTextField(
                     value = uiState.email,
-                    onValueChange = onEmailInput
+                    onValueChange = onEmailInput,
+                    placeholder = "Email"
                 )
 
                 PasswordTextField(
                     value = uiState.password,
                     onValueChange = onPasswordInput,
                     label = "Password",
-                    passwordVisible = passwordVisible,
-                    onPasswordVisibilityToggle = { passwordVisible = !passwordVisible }
+                    placeholder = "Password",
+                    passwordVisible = isPasswordVisible,
+                    onPasswordVisibilityToggle = onPasswordVisibilityToggle
                 )
 
                 PasswordTextField(
                     value = uiState.confirmPassword,
                     onValueChange = onConfirmPasswordInput,
                     label = "Confirm Password",
-                    passwordVisible = confirmPasswordVisible,
-                    onPasswordVisibilityToggle = { confirmPasswordVisible = !confirmPasswordVisible }
+                    placeholder = "Confirm Password",
+                    passwordVisible = isConfirmPasswordVisible,
+                    onPasswordVisibilityToggle = onConfirmPasswordVisibilityToggle
                 )
             }
 
@@ -139,6 +146,10 @@ fun PreviewRegisterScreen() {
             onEmailInput = {},
             onPasswordInput = {},
             onConfirmPasswordInput = {},
+            onPasswordVisibilityToggle = {},
+            onConfirmPasswordVisibilityToggle = {},
+            isPasswordVisible = false,
+            isConfirmPasswordVisible = false,
             onSignUpClick = {},
             onGoogleClick = {},
             onBackClick = {}

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterUiState.kt
@@ -3,5 +3,7 @@ package com.tpc.nudj.ui.screen.auth.register
 data class RegisterUiState(
     val email: String = "",
     val password: String = "",
-    val confirmPassword: String = ""
+    val confirmPassword: String = "",
+    val isPasswordVisible: Boolean= false,
+    val isConfirmPasswordVisible: Boolean = false
 )

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterUiState.kt
@@ -1,0 +1,7 @@
+package com.tpc.nudj.ui.screen.auth.register
+
+data class RegisterUiState(
+    val email: String = "",
+    val password: String = "",
+    val confirmPassword: String = ""
+)

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/register/RegisterUiState.kt
@@ -5,5 +5,6 @@ data class RegisterUiState(
     val password: String = "",
     val confirmPassword: String = "",
     val isPasswordVisible: Boolean= false,
-    val isConfirmPasswordVisible: Boolean = false
+    val isConfirmPasswordVisible: Boolean = false,
+    val isLoading: Boolean = false
 )

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/emailVerification/EmailVerificationViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/emailVerification/EmailVerificationViewModel.kt
@@ -1,1 +1,20 @@
 package com.tpc.nudj.viewmodels.auth.emailVerification
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import com.tpc.nudj.ui.screen.auth.emailVerification.EmailVerificationUiState
+
+@HiltViewModel
+class EmailVerificationViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState = MutableStateFlow(EmailVerificationUiState())
+    val uiState: StateFlow<EmailVerificationUiState> = _uiState.asStateFlow()
+
+    fun onCheckInboxClick() {}
+    fun onResendEmailClick() {}
+
+}

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/emailVerification/EmailVerificationViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/emailVerification/EmailVerificationViewModel.kt
@@ -1,20 +1,47 @@
 package com.tpc.nudj.viewmodels.auth.emailVerification
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import com.tpc.nudj.ui.screen.auth.emailVerification.EmailVerificationUiState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class EmailVerificationViewModel @Inject constructor() : ViewModel() {
 
     private val _uiState = MutableStateFlow(EmailVerificationUiState())
     val uiState: StateFlow<EmailVerificationUiState> = _uiState.asStateFlow()
+    fun onResendEmailClick() {
+        startTimer()
+    }
 
-    fun onCheckInboxClick() {}
-    fun onResendEmailClick() {}
 
+
+    private var timerJob: Job? = null
+
+    fun startTimer(){
+        timerJob?.cancel()
+        timerJob = viewModelScope.launch {
+
+            _uiState.update {
+                it.copy(isResendEnabled = false, timerInSeconds = 30)
+            }
+            for(i in 29 downTo 0){
+                delay(1000)
+                _uiState.update { it.copy(timerInSeconds = i) }
+            }
+            _uiState.update {
+                it.copy(isResendEnabled = true)
+            }
+        }
+
+    }
 }

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/register/RegisterViewModel.kt
@@ -1,12 +1,15 @@
 package com.tpc.nudj.viewmodels.auth.register
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.tpc.nudj.ui.screen.auth.register.RegisterUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,7 +30,14 @@ class RegisterViewModel @Inject constructor() : ViewModel() {
         _registerUiState.update { it.copy(confirmPassword = newPassword) }
     }
 
-    fun onRegisterClick() {}
+    fun onRegisterClick() {
+
+        viewModelScope.launch {
+//            _registerUiState.update { it.copy(isLoading = true) }
+//            delay(2000)
+//            _registerUiState.update { it.copy(isLoading = false) }
+        }
+    }
 
     fun onGoogleClick() {}
 

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/register/RegisterViewModel.kt
@@ -26,4 +26,19 @@ class RegisterViewModel @Inject constructor() : ViewModel() {
     fun onConfirmPasswordChange(newPassword: String) {
         _registerUiState.update { it.copy(confirmPassword = newPassword) }
     }
+
+    fun onRegisterClick() {}
+
+    fun onGoogleClick() {}
+
+    fun onPasswordVisibilityToggle(){
+        _registerUiState.update { it.copy(isPasswordVisible = !it.isPasswordVisible) }
+    }
+
+    fun onConfirmPasswordVisibilityToggle(){
+        _registerUiState.update { it.copy(isConfirmPasswordVisible = !it.isConfirmPasswordVisible) }
+    }
+
+
+
 }

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/register/RegisterViewModel.kt
@@ -1,1 +1,29 @@
 package com.tpc.nudj.viewmodels.auth.register
+
+import androidx.lifecycle.ViewModel
+import com.tpc.nudj.ui.screen.auth.register.RegisterUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class RegisterViewModel @Inject constructor() : ViewModel() {
+
+    private val _registerUiState = MutableStateFlow(RegisterUiState())
+    val registerUiState: StateFlow<RegisterUiState> = _registerUiState.asStateFlow()
+
+    fun onEmailChange(newEmail: String) {
+        _registerUiState.update { it.copy(email = newEmail) }
+    }
+
+    fun onPasswordChange(newPassword: String) {
+        _registerUiState.update { it.copy(password = newPassword) }
+    }
+
+    fun onConfirmPasswordChange(newPassword: String) {
+        _registerUiState.update { it.copy(confirmPassword = newPassword) }
+    }
+}


### PR DESCRIPTION
# Pull Request – Nudj Contribution


## 🔧 What does this PR do?

Added Register and Email Verification Screen with VeiwModel and Data Class.

---

## 🧩 Related Issue

> Mention the issue this PR resolves #12 

Closes: #12 

---

## 📸 Screenshots / UI Demo (If applicable)
<img width="707" height="727" alt="Screenshot 2026-06-12 at 2 07 50 PM" src="https://github.com/user-attachments/assets/cfd5dd39-a376-4fc8-9576-2fed26b51000" />
<img width="730" height="781" alt="Screenshot 2026-06-12 at 2 08 21 PM" src="https://github.com/user-attachments/assets/1aa1d7ea-20e6-46b5-b204-ecfba061d3f0" />


---

## ✅ Checklist

- [x] My code follows the project's style and structure
- [x] I’ve tested my changes locally
- [x] I’ve not committed any files directly to `main`
- [x] I’ve commented my approach in the linked issue
- [x] My commit messages are clean and meaningful
- [x] This PR focuses on one clear task/feature only

---

## 🧠 Brief Explanation of Approach

Built Register and Email Verification screens with component-driven Compose architecture:

1. Lifecycle State Management: Implemted ViewModels and UI state data class using StateFLow , used collectAsStateWithLifecycle() instead of standard state to prevent background drain and optimize performance.
2. Used comonents that are already present in the code base button.kt , textfield.kt and so on.
3. 
