### PR TITLE
Reset password screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.hilt)
     //ksp
     alias(libs.plugins.ksp)
-    alias(libs.plugins.google.gms.google.services)
+    // alias(libs.plugins.google.gms.google.services)
 }
 
 val localPropertiesFile = rootProject.file("local.properties")

--- a/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
@@ -84,12 +84,14 @@ fun NudjTextField(
 fun EmailTextField(
     value: String,
     onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
     placeholder: String = "Institute Mail id"
 ) {
     NudjTextField(
         value = value,
         onValueChange = onValueChange,
         placeholder = placeholder,
+        modifier = modifier,
         leadingIcon = {
             Icon(
                 imageVector = Icons.Outlined.Mail,

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordScreen.kt
@@ -35,6 +35,7 @@ import com.tpc.nudj.ui.components.LoadingIndicator
 import com.tpc.nudj.ui.theme.LocalAppColors
 import com.tpc.nudj.viewmodels.auth.ResetPassword.ResetPasswordViewModel
 import com.tpc.nudj.R
+import com.tpc.nudj.ui.components.NudjLogo
 import com.tpc.nudj.ui.components.PasswordTextField
 import com.tpc.nudj.ui.components.PrimaryButton
 import com.tpc.nudj.ui.components.TertiaryButton
@@ -42,7 +43,8 @@ import com.tpc.nudj.ui.theme.NudjTheme
 
 @Composable
 fun ResetPasswordScreen(
-    viewModel: ResetPasswordViewModel = hiltViewModel()
+    viewModel: ResetPasswordViewModel = hiltViewModel(),
+    onLoginClick :() ->Unit
 ) {
     Scaffold(
         containerColor = LocalAppColors.current.background
@@ -58,7 +60,7 @@ fun ResetPasswordScreen(
                 onPasswordVisibilityToggle = viewModel::togglePasswordVisibility,
                 onConfirmPasswordVisibilityToggle = viewModel::toggleConfirmPasswordVisibility,
                 onSubmitClick = viewModel::onSubmitClick,
-                onLoginClick = viewModel::onLoginClick
+                onLoginClick = onLoginClick
             )
         }
     }
@@ -73,7 +75,6 @@ fun ResetPasswordScreenLayout(
     onSubmitClick: () -> Unit,
     onLoginClick: () -> Unit
 ) {
-    val darkTheme = isSystemInDarkTheme()
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -82,39 +83,14 @@ fun ResetPasswordScreenLayout(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.height(56.dp))
-
-        Image(
-            painter = painterResource(
-                if (darkTheme) {
-                    R.drawable.nudj_logo_dark_theme
-                } else {
-                    R.drawable.nudj_logo
-                }
-            ),
-            contentDescription = "Nudj logo",
-            modifier = Modifier.size(72.dp)
-        )
-
-        Image(
-            painter = painterResource(
-                if (darkTheme) {
-                    R.drawable.nudj_dark_theme
-                } else {
-                    R.drawable.nudj
-                }
-            ),
-            contentDescription = "Nudj",
-            modifier = Modifier
-                .width(90.dp)
-                .height(40.dp)
-        )
+        NudjLogo()
 
         Spacer(modifier = Modifier.height(96.dp))
 
         Text(
-            text = "Submit",
+            text = "Reset Password",
             style = MaterialTheme.typography.titleLarge,
-            color = LocalAppColors.current.secondaryButtonTextColor
+            color = LocalAppColors.current.onBackground
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -153,7 +129,7 @@ fun ResetPasswordScreenLayout(
         Spacer(modifier = Modifier.height(64.dp))
 
         PrimaryButton(
-            text = "Reset Password",
+            text = "Submit",
             onClick = onSubmitClick,
             enabled = !uiState.isLoading,
             modifier = Modifier

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordScreen.kt
@@ -1,10 +1,11 @@
-package com.tpc.nudj.ui.screen.auth.forgotPassword
+package com.tpc.nudj.ui.screen.auth.Reset
 
 import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -25,63 +26,62 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.tpc.nudj.R
-import com.tpc.nudj.ui.components.EmailTextField
 import com.tpc.nudj.ui.components.LoadingIndicator
-import com.tpc.nudj.ui.components.NudjTopAppBar
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.viewmodels.auth.ResetPassword.ResetPasswordViewModel
+import com.tpc.nudj.R
+import com.tpc.nudj.ui.components.PasswordTextField
 import com.tpc.nudj.ui.components.PrimaryButton
 import com.tpc.nudj.ui.components.TertiaryButton
-import com.tpc.nudj.ui.screen.auth.login.LoginScreenLayout
-import com.tpc.nudj.ui.screen.auth.login.LoginUiState
-import com.tpc.nudj.ui.theme.LocalAppColors
 import com.tpc.nudj.ui.theme.NudjTheme
-import com.tpc.nudj.viewmodels.auth.forgotPassword.ForgotPasswordViewModel
 
 @Composable
-fun ForgetPasswordScreen(
-    viewModel: ForgotPasswordViewModel = hiltViewModel(),
-
+fun ResetPasswordScreen(
+    viewModel: ResetPasswordViewModel = hiltViewModel()
 ) {
     Scaffold(
         containerColor = LocalAppColors.current.background
     ) { paddingValues ->
-        val uiState by viewModel.forgotPasswordUiState.collectAsState()
-        LoadingIndicator(isLoading = uiState.isLoading) {
 
-            ForgetPasswordScreenLayout(
+        val uiState by viewModel.resetPasswordUiState.collectAsState()
+        LoadingIndicator(isLoading = uiState.isLoading) {
+            ResetPasswordScreenLayout(
                 modifier = Modifier.padding(paddingValues),
                 uiState = uiState,
-                onEmailInput = viewModel::onEmailChange,
-                onLoginClick = viewModel::onLoginClick,
-                onSendEmailClick = viewModel::onSendEmailClick
-
+                onPasswordInput = viewModel::onPasswordChange,
+                onConfirmPasswordInput = viewModel::onConfirmPasswordChange,
+                onPasswordVisibilityToggle = viewModel::togglePasswordVisibility,
+                onConfirmPasswordVisibilityToggle = viewModel::toggleConfirmPasswordVisibility,
+                onSubmitClick = viewModel::onSubmitClick,
+                onLoginClick = viewModel::onLoginClick
             )
         }
     }
-}
-
-@Composable
-fun ForgetPasswordScreenLayout(
+}@Composable
+fun ResetPasswordScreenLayout(
+    uiState: ResetPasswordUiState,
     modifier: Modifier = Modifier,
-    uiState: ForgotPasswordUiState,
-    onEmailInput : (String) -> Unit,
-    onLoginClick :()-> Unit,
-    onSendEmailClick: () -> Unit
-
-){
+    onPasswordInput: (String) -> Unit,
+    onConfirmPasswordInput: (String) -> Unit,
+    onPasswordVisibilityToggle: () -> Unit,
+    onConfirmPasswordVisibilityToggle: () -> Unit,
+    onSubmitClick: () -> Unit,
+    onLoginClick: () -> Unit
+) {
     val darkTheme = isSystemInDarkTheme()
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(LocalAppColors.current.background)
-            .padding(horizontal = 32.dp),
+            .padding(horizontal = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(modifier = Modifier.height(72.dp))
+        Spacer(modifier = Modifier.height(56.dp))
 
         Image(
             painter = painterResource(
@@ -109,10 +109,10 @@ fun ForgetPasswordScreenLayout(
                 .height(40.dp)
         )
 
-        Spacer(modifier = Modifier.height(120.dp))
+        Spacer(modifier = Modifier.height(96.dp))
 
         Text(
-            text = "Enter your email address",
+            text = "Submit",
             style = MaterialTheme.typography.titleLarge,
             color = LocalAppColors.current.secondaryButtonTextColor
         )
@@ -126,19 +126,35 @@ fun ForgetPasswordScreenLayout(
                 containerColor = LocalAppColors.current.surfaceColor
             )
         ) {
-            EmailTextField(
-                value = uiState.email,
-                onValueChange = onEmailInput,
-                placeholder = "Institute mail id",
+            Column(
                 modifier = Modifier.padding(16.dp)
-            )
+            ) {
+                PasswordTextField(
+                    value = uiState.password,
+                    onValueChange = onPasswordInput,
+                    passwordVisible = uiState.passwordVisible,
+                    onPasswordVisibilityToggle =
+                        onPasswordVisibilityToggle,
+                    placeholder = "New Password"
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                PasswordTextField(
+                    value = uiState.confirmPassword,
+                    onValueChange = onConfirmPasswordInput,
+                    passwordVisible = uiState.confirmPasswordVisible,
+                    onPasswordVisibilityToggle = onConfirmPasswordVisibilityToggle,
+                    placeholder = "Confirm Password"
+                )
+            }
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(64.dp))
 
         PrimaryButton(
             text = "Reset Password",
-            onClick = onSendEmailClick,
+            onClick = onSubmitClick,
             enabled = !uiState.isLoading,
             modifier = Modifier
                 .fillMaxWidth()
@@ -164,20 +180,20 @@ fun ForgetPasswordScreenLayout(
             )
         }
     }
-
 }
-
 @Preview(showBackground = true)
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun ForgetPasswordScreenLayoutPreview() {
+private fun ResetPasswordScreenLayoutPreview() {
     NudjTheme {
-        ForgetPasswordScreenLayout(
-            modifier = Modifier,
-            uiState = ForgotPasswordUiState(),
-            onEmailInput = {},
-            onLoginClick = {},
-            onSendEmailClick = {}
+        ResetPasswordScreenLayout(
+            uiState = ResetPasswordUiState(),
+            onPasswordInput = {},
+            onConfirmPasswordInput = {},
+            onPasswordVisibilityToggle = {},
+            onConfirmPasswordVisibilityToggle = {},
+            onSubmitClick = {},
+            onLoginClick = {}
         )
     }
 }

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -39,7 +40,7 @@ fun ResetPasswordScreen(
     onLoginClick :() ->Unit
 ) {
     Scaffold(
-
+        containerColor = LocalAppColors.current.background
     ) { paddingValues ->
 
         val uiState by viewModel.resetPasswordUiState.collectAsState()
@@ -70,7 +71,6 @@ fun ResetPasswordScreenLayout(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(LocalAppColors.current.background)
             .padding(horizontal = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -154,14 +154,19 @@ fun ResetPasswordScreenLayout(
 @Composable
 private fun ResetPasswordScreenLayoutPreview() {
     NudjTheme {
-        ResetPasswordScreenLayout(
-            uiState = ResetPasswordUiState(),
-            onPasswordInput = {},
-            onConfirmPasswordInput = {},
-            onPasswordVisibilityToggle = {},
-            onConfirmPasswordVisibilityToggle = {},
-            onSubmitClick = {},
-            onLoginClick = {}
-        )
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = LocalAppColors.current.background
+        ) {
+            ResetPasswordScreenLayout(
+                uiState = ResetPasswordUiState(),
+                onPasswordInput = {},
+                onConfirmPasswordInput = {},
+                onPasswordVisibilityToggle = {},
+                onConfirmPasswordVisibilityToggle = {},
+                onSubmitClick = {},
+                onLoginClick = {}
+            )
+        }
     }
 }

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/Reset/ResetPasswordUiState.kt
@@ -1,0 +1,11 @@
+package com.tpc.nudj.ui.screen.auth.Reset
+
+data class ResetPasswordUiState(
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val toastMessage: String? = null,
+    val password: String = "",
+    val confirmPassword: String = "",
+    val passwordVisible: Boolean = false,
+    val confirmPasswordVisible: Boolean = false
+)

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
@@ -40,6 +40,7 @@ fun ForgetPasswordScreen(
 
 ) {
     Scaffold(
+        containerColor = LocalAppColors.current.background
 
     ) { paddingValues ->
         val uiState by viewModel.forgotPasswordUiState.collectAsState()
@@ -70,7 +71,6 @@ fun ForgetPasswordScreenLayout(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(LocalAppColors.current.background)
             .padding(horizontal = 32.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/forgotPassword/ForgetPasswordScreen.kt
@@ -32,6 +32,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.tpc.nudj.R
 import com.tpc.nudj.ui.components.EmailTextField
 import com.tpc.nudj.ui.components.LoadingIndicator
+import com.tpc.nudj.ui.components.NudjLogo
 import com.tpc.nudj.ui.components.NudjTopAppBar
 import com.tpc.nudj.ui.components.PrimaryButton
 import com.tpc.nudj.ui.components.TertiaryButton
@@ -44,6 +45,7 @@ import com.tpc.nudj.viewmodels.auth.forgotPassword.ForgotPasswordViewModel
 @Composable
 fun ForgetPasswordScreen(
     viewModel: ForgotPasswordViewModel = hiltViewModel(),
+    onLoginClick: () -> Unit
 
 ) {
     Scaffold(
@@ -56,7 +58,7 @@ fun ForgetPasswordScreen(
                 modifier = Modifier.padding(paddingValues),
                 uiState = uiState,
                 onEmailInput = viewModel::onEmailChange,
-                onLoginClick = viewModel::onLoginClick,
+                onLoginClick = onLoginClick,
                 onSendEmailClick = viewModel::onSendEmailClick
 
             )
@@ -73,7 +75,7 @@ fun ForgetPasswordScreenLayout(
     onSendEmailClick: () -> Unit
 
 ){
-    val darkTheme = isSystemInDarkTheme()
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -83,31 +85,7 @@ fun ForgetPasswordScreenLayout(
     ) {
         Spacer(modifier = Modifier.height(72.dp))
 
-        Image(
-            painter = painterResource(
-                if (darkTheme) {
-                    R.drawable.nudj_logo_dark_theme
-                } else {
-                    R.drawable.nudj_logo
-                }
-            ),
-            contentDescription = "Nudj logo",
-            modifier = Modifier.size(72.dp)
-        )
-
-        Image(
-            painter = painterResource(
-                if (darkTheme) {
-                    R.drawable.nudj_dark_theme
-                } else {
-                    R.drawable.nudj
-                }
-            ),
-            contentDescription = "Nudj",
-            modifier = Modifier
-                .width(90.dp)
-                .height(40.dp)
-        )
+        NudjLogo()
 
         Spacer(modifier = Modifier.height(120.dp))
 

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/ResetPassword/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/ResetPassword/ResetPasswordViewModel.kt
@@ -44,7 +44,5 @@ class ResetPasswordViewModel @Inject constructor() : ViewModel() {
     fun onSubmitClick() {
 
     }
-    fun onLoginClick() {
 
-    }
 }

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/ResetPassword/ResetPasswordViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/ResetPassword/ResetPasswordViewModel.kt
@@ -1,0 +1,50 @@
+package com.tpc.nudj.viewmodels.auth.ResetPassword
+
+import androidx.lifecycle.ViewModel
+import com.tpc.nudj.ui.screen.auth.Reset.ResetPasswordUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class ResetPasswordViewModel @Inject constructor() : ViewModel() {
+
+    private val _resetPasswordUiState = MutableStateFlow(ResetPasswordUiState())
+    val resetPasswordUiState: StateFlow<ResetPasswordUiState> = _resetPasswordUiState.asStateFlow()
+
+    fun onPasswordChange(password: String) {
+        _resetPasswordUiState.update {
+            it.copy(password = password)
+        }
+    }
+
+    fun onConfirmPasswordChange(confirmPassword: String) {
+        _resetPasswordUiState.update {
+            it.copy(confirmPassword = confirmPassword)
+        }
+    }
+
+    fun togglePasswordVisibility() {
+        _resetPasswordUiState.update {
+            it.copy(passwordVisible = !it.passwordVisible)
+        }
+    }
+
+    fun toggleConfirmPasswordVisibility() {
+        _resetPasswordUiState.update {
+            it.copy(
+                confirmPasswordVisible = !it.confirmPasswordVisible
+            )
+        }
+    }
+
+    fun onSubmitClick() {
+
+    }
+    fun onLoginClick() {
+
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
@@ -24,7 +24,5 @@ class ForgotPasswordViewModel @Inject constructor() : ViewModel() {
     fun onSendEmailClick(){
 
     }
-    fun onLoginClick(){
 
-    }
 }

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/forgotPassword/ForgotPasswordViewModel.kt
@@ -24,4 +24,7 @@ class ForgotPasswordViewModel @Inject constructor() : ViewModel() {
     fun onSendEmailClick(){
 
     }
+    fun onLoginClick(){
+
+    }
 }


### PR DESCRIPTION
# Pull Request – Nudj Contribution


---

## 🔧 What does this PR do?


- Revamped the forget password screen as per the figma design
- Created the reset password screen similar to the figma design

---

## 🧩 Related Issue

Closes: #24 

---

## 📸 Screenshots / UI Demo (If applicable)

> 
<img width="642" height="704" alt="Screenshot 2026-06-27 at 4 54 47 PM" src="https://github.com/user-attachments/assets/d0f0b71f-9a9a-4652-97ea-18a4ca0c4e5b" />

<img width="640" height="708" alt="Screenshot 2026-06-27 at 4 57 46 PM" src="https://github.com/user-attachments/assets/67653044-c09e-496a-9f7f-1962ce5dde54" />



---

## ✅ Checklist

-  [] My code follows the project's style and structure
- [x] I’ve tested my changes locally
- [x] I’ve not committed any files directly to `main`
- [x] I’ve commented my approach in the linked issue
- [x] My commit messages are clean and meaningful
- [x] This PR focuses on one clear task/feature only

---

## 🧠 Brief Explanation of Approach

I have made a reset screen (the viewmodel , ui state and the screen and layout composables ), and changed the forgetPassword acc. to the figma.

---

## 
---
