### PR TITLE
Integrated Club Verification Screen with Firebase

### DIFF
--- a/app/src/main/java/com/tpc/nudj/MainActivity.kt
+++ b/app/src/main/java/com/tpc/nudj/MainActivity.kt
@@ -156,7 +156,15 @@ class MainActivity : ComponentActivity() {
                             ClubLandingScreen()
                         }
                         entry<ScreenRoute.App.ClubVerificationScreen>{
-                            ClubVerificationScreen(onNavigationBack = {})
+                            ClubVerificationScreen(
+                                onNavigationBack = {
+                                    backStack.removeLast()
+                                },
+                                onNavigateToDashboard = {
+                                    backStack.clear()
+                                    backStack.add(ScreenRoute.App.ClubDashboard)
+                                }
+                            )
                         }
                         entry<ScreenRoute.App.UserDetailsInput> {
                             DemoScreen(text = "User Details Input")

--- a/app/src/main/java/com/tpc/nudj/MainActivity.kt
+++ b/app/src/main/java/com/tpc/nudj/MainActivity.kt
@@ -158,7 +158,7 @@ class MainActivity : ComponentActivity() {
                         entry<ScreenRoute.App.ClubVerificationScreen>{
                             ClubVerificationScreen(
                                 onNavigationBack = {
-                                    backStack.removeLast()
+                                    backStack.removeLastOrNull()
                                 },
                                 onNavigateToDashboard = {
                                     backStack.clear()

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/clubVerification/ClubVerificationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/clubVerification/ClubVerificationScreen.kt
@@ -42,7 +42,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun ClubVerificationScreen(
     viewModel: ClubVerificationViewModel = hiltViewModel(),
-    onNavigationBack: () -> Unit
+    onNavigationBack: () -> Unit,
+    onNavigateToDashboard: () -> Unit
 ) {
     val clubVerificationUiState by viewModel.clubVerificationUiState.collectAsStateWithLifecycle()
 
@@ -57,15 +58,14 @@ fun ClubVerificationScreen(
             onBackClick = onNavigationBack,
             snackbarHostState = snackbarHostState,
             onCheckStatusClick = {
-                viewModel.onCheckStatusClick()
-                scope.launch {
-                    val message = if(clubVerificationUiState.isVerified){
-                        "Verified"
-                    } else {
-                        "Not Verified"
+                viewModel.onCheckStatusClick(
+                    onApproved = onNavigateToDashboard,
+                    onMessage = { message ->
+                        scope.launch {
+                            snackbarHostState.showSnackbar(message)
+                        }
                     }
-                    snackbarHostState.showSnackbar(message)
-                }
+                )
             }
         )
     }

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/clubVerification/ClubVerificationUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/clubVerification/ClubVerificationUiState.kt
@@ -3,5 +3,6 @@ package com.tpc.nudj.ui.screen.auth.clubVerification
 
 data class ClubVerificationUiState(
     val isLoading: Boolean = false,
-    val isVerified: Boolean = false
-    )
+    val isVerified: Boolean = false,
+    val verificationStatus: String = "pending"
+)

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/clubVerification/ClubVerificationViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/clubVerification/ClubVerificationViewModel.kt
@@ -1,11 +1,11 @@
 package com.tpc.nudj.viewmodels.auth.clubVerification
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.tpc.nudj.repository.user.UserRepository
 import com.tpc.nudj.ui.screen.auth.clubVerification.ClubVerificationUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,21 +15,46 @@ import javax.inject.Inject
 
 
 @HiltViewModel
-class ClubVerificationViewModel @Inject constructor() : ViewModel() {
+class ClubVerificationViewModel @Inject constructor(
+    private val userRepository: UserRepository
+) : ViewModel() {
     private val _clubVerificationUiState = MutableStateFlow(ClubVerificationUiState())
-    val clubVerificationUiState:StateFlow<ClubVerificationUiState> =
+    val clubVerificationUiState: StateFlow<ClubVerificationUiState> =
         _clubVerificationUiState.asStateFlow()
 
-    fun onCheckStatusClick() {
+    private val auth = FirebaseAuth.getInstance()
+
+    fun onCheckStatusClick(onApproved: () -> Unit, onMessage: (String) -> Unit) {
+        val uid = auth.currentUser?.uid ?: return
         viewModelScope.launch {
             _clubVerificationUiState.update {
                 it.copy(isLoading = true)
             }
 
-            delay(1000)
-
-            _clubVerificationUiState.update {
-                it.copy(isLoading = false)
+            try {
+                val status = userRepository.fetchClubVerificationStatus(uid)
+                _clubVerificationUiState.update {
+                    it.copy(
+                        isLoading = false,
+                        verificationStatus = status,
+                        isVerified = status == "approved"
+                    )
+                }
+                
+                when (status) {
+                    "approved" -> {
+                        onMessage("Verification Successful!")
+                        onApproved()
+                    }
+                    "pending" -> onMessage("Verification is still pending. Please wait.")
+                    "rejected" -> onMessage("Verification rejected. Please contact support.")
+                    else -> onMessage("Current status: $status")
+                }
+            } catch (e: Exception) {
+                _clubVerificationUiState.update {
+                    it.copy(isLoading = false)
+                }
+                onMessage("Error checking status: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/clubVerification/ClubVerificationViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/clubVerification/ClubVerificationViewModel.kt
@@ -54,7 +54,7 @@ class ClubVerificationViewModel @Inject constructor(
                 _clubVerificationUiState.update {
                     it.copy(isLoading = false)
                 }
-                onMessage("Error checking status: ${e.message}")
+                onMessage("Error checking status. Please try again.")
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Integrates ClubVerificationScreen into the app's navigation flow, replacing the previous placeholder. Adds status-check logic that calls UserRepository.fetchClubVerificationStatus and surfaces the result to the user via a Snackbar, and automatically navigates approved club admins to ClubDashboard.

##  Related Issue

Closes: #34 

## Brief Explanation of Approach

1. ClubVerificationViewModel now injects UserRepository and uses FirebaseAuth.getInstance() to get the current admin's uid. onCheckStatusClick was changed to accept two callbacks - onApproved: () -> Unit and onMessage: (String) -> Unit — instead of the screen inferring a message itself from isVerified. Inside the ViewModel:

2. Sets isLoading = true, calls userRepository.fetchClubVerificationStatus(uid).

3. Updates ClubVerificationUiState with the new verificationStatus field (added alongside the existing isVerified flag) and isLoading = false.
Branches on the returned status string:

4. "approved" → fires onMessage("Verification Successful!") then onApproved().
"pending" → fires a "still pending" message, no navigation.
"rejected" → fires a "contact support" message, no navigation.
any other value → falls back to showing the raw status.

5. Wraps the call in try/catch so network/Firestore failures reset isLoading and tell us an error message via onMessage..

6. ClubVerificationScreen was simplified to just pass these two callbacks through to the ViewModel, with onMessage launching a coroutine to show the Snackbar - removing the screen's own logic for deciding what message to display.
In MainActivity, the ClubVerificationScreen entry now passes:

onNavigationBack = { backStack.removeLast() }
onNavigateToDashboard = { backStack.clear(); backStack.add(ScreenRoute.App.ClubDashboard) }

## Additional Notes

1. uid is fetched via auth.currentUser?.uid ?: return - if there's no signed-in use

2. Added error handling which is now in place for the status-fetch call (catch (e: Exception) → onMessage("Error checking status: ${e.message}")).

3. isVerified is retained in ClubVerificationUiState along with the new verificationStatus field .