### PR TITLE
Create and Edit Screen Implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation("androidx.compose.material:material-icons-extended")
     implementation(libs.kotlinx.serialization.core)
+    implementation("io.coil-kt:coil-compose:2.7.0")
 
     //navigation
     implementation(libs.androidx.navigation3.ui)

--- a/app/src/main/java/com/tpc/nudj/model/enums/FormType.kt
+++ b/app/src/main/java/com/tpc/nudj/model/enums/FormType.kt
@@ -1,0 +1,6 @@
+package com.tpc.nudj.model.enums
+
+enum class FormType {
+    CLUB,
+    GENERAL_EVENT,
+}

--- a/app/src/main/java/com/tpc/nudj/model/enums/ImagePickerType.kt
+++ b/app/src/main/java/com/tpc/nudj/model/enums/ImagePickerType.kt
@@ -1,0 +1,10 @@
+package com.tpc.nudj.model.enums
+
+enum class ImagePickerType {
+    CLUB_LOGO,
+    EVENT_LOGO,
+    EVENT_BANNER,
+    EVENT_PHOTO_1,
+    EVENT_PHOTO_2,
+    EVENT_PHOTO_3
+}

--- a/app/src/main/java/com/tpc/nudj/ui/components/DynamicTextFieldList.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/DynamicTextFieldList.kt
@@ -1,0 +1,94 @@
+package com.tpc.nudj.ui.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AddCircleOutline
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.motionEventSpy
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.ui.theme.NudjTheme
+
+@Composable
+fun DynamicTextFieldList(
+    title: String,
+    items: List<String>,
+    placeholder: String,
+    onValueChange: (Int, String) -> Unit,
+    onAddClick : () -> Unit,
+    onDeleteClick :(Int) -> Unit,
+){
+    Column(){
+        Text(
+            text=title,
+            style= MaterialTheme.typography.titleMedium,
+            color = LocalAppColors.current.onBackground
+        )
+        items.forEachIndexed { index, string ->
+            Row(
+                modifier=Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ){
+                NudjTextField(
+                    value = string,
+                    onValueChange = { onValueChange(index,it) },
+                    placeholder = placeholder,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(
+                    onClick = {
+                        if (index == items.lastIndex)
+                            onAddClick()
+                        else
+                            onDeleteClick(index)
+                    }
+                ) {
+                    Icon(
+                        imageVector = if (index == items.lastIndex)
+                            Icons.Default.AddCircleOutline
+                        else
+                            Icons.Default.Delete,
+                        contentDescription = null,
+                        tint = LocalAppColors.current.onBackground
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true , uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun DynamicTextFieldListPreview() {
+    NudjTheme {
+        DynamicTextFieldList(
+            title = "Achievements",
+            items = listOf(
+                "Winner - Hackathon 2025",
+                "Runner-up - Coding Contest",
+                ""
+            ),
+            placeholder = "If any",
+            onValueChange = { _, _ -> },
+            onAddClick = { },
+            onDeleteClick = { }
+        )
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/components/NudjDropDownMenu.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/NudjDropDownMenu.kt
@@ -22,40 +22,45 @@ import com.tpc.nudj.ui.theme.LocalAppColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NudjDropDownMenu(
+fun <T> NudjDropDownMenu(
 
     expanded: Boolean = false,
-    onSelectedOptionChange: (Int) -> Unit,
-    selectedOption: Int?,
-    options: List<Int>,
+    onSelectedOptionChange: (T) -> Unit,
+    selectedOption: T?,
+    options: List<T>,
     placeholder: String,
-    trailingIcon: ImageVector,
-    leadingIcon: ImageVector,
+    trailingIcon: ImageVector?=null,
+    leadingIcon: ImageVector?=null,
     onExpandedStateChange: (Boolean) -> Unit,
+    optionLabel: (T) -> String = { it.toString() }
 ) {
     ExposedDropdownMenuBox(
         expanded = expanded,
         onExpandedChange = onExpandedStateChange,
     ) {
         NudjTextField(
-            value = selectedOption?.toString() ?: "",
+            value = selectedOption?.let(optionLabel) ?: "",
             onValueChange = {},
             placeholder = placeholder,
 
-            trailingIcon = {
-                Icon(
-                    imageVector = trailingIcon,
-                    contentDescription = "trailingIcon"
-                )
+            trailingIcon = trailingIcon?.let{ icon ->
+                {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = "trailingIcon"
+                    )
+                }
             },
-            leadingIcon = {
-                Icon(
-                    imageVector = leadingIcon,
-                    contentDescription = "leadingIcon",
-                )
+            leadingIcon = leadingIcon?.let{ icon ->
+                {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = "leadingIcon"
+                    )
+                }
             },
             modifier = Modifier
-                .padding(10.dp)
+
                 .menuAnchor(
                     type = ExposedDropdownMenuAnchorType.PrimaryNotEditable,
                     enabled = true
@@ -76,7 +81,7 @@ fun NudjDropDownMenu(
 
                     text = {
                         Text(
-                            text = "$option",
+                            text = optionLabel(option),
                             style = MaterialTheme.typography.bodyLarge,
                             color = Color.Black
                         )

--- a/app/src/main/java/com/tpc/nudj/ui/components/NudjImagePicker.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/NudjImagePicker.kt
@@ -1,0 +1,53 @@
+package com.tpc.nudj.ui.components
+
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AddCircleOutline
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.Shape
+import coil.compose.AsyncImage
+import com.tpc.nudj.ui.theme.LocalAppColors
+
+@Composable
+fun NudjImagePicker(
+    imageUri: Uri?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = CircleShape,
+    placeholderIcon: ImageVector = Icons.Default.AddCircleOutline,
+    contentDescription: String? = null
+) {
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .background(color = LocalAppColors.current.textFieldColor)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        if (imageUri == null) {
+            Icon(
+                imageVector = placeholderIcon,
+                contentDescription = contentDescription
+            )
+        } else {
+            AsyncImage(
+                model = imageUri,
+                contentDescription = contentDescription,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/TextFields.kt
@@ -139,6 +139,51 @@ fun PasswordTextField(
         }
     )
 }
+@Composable
+fun NudjDescriptionTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+    title : String
+) {
+    Column(){
+        Text(
+            text=title,
+            style = MaterialTheme.typography.titleMedium,
+            color=LocalAppColors.current.onBackground
+            )
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            placeholder = {
+                Text(
+                    text = placeholder,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            },
+            modifier = modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(8.dp),
+
+            singleLine = false,
+            minLines = 5,
+
+            textStyle = MaterialTheme.typography.bodyLarge,
+
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = LocalAppColors.current.textFieldColor,
+                unfocusedContainerColor = LocalAppColors.current.textFieldColor,
+                focusedBorderColor = LocalAppColors.current.textFieldBorderColor,
+                unfocusedBorderColor = LocalAppColors.current.textFieldBorderColor,
+                focusedTextColor = Color.Black,
+                unfocusedTextColor = Color.Black,
+                focusedPlaceholderColor = Color(0xFF728C9D),
+                unfocusedPlaceholderColor = Color(0xFF728C9D),
+                cursorColor = Color.Black
+            )
+        )
+    }
+}
 
 @Preview(name = "Light Mode", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "Dark Mode", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/app/src/main/java/com/tpc/nudj/ui/layouts/ClubDetailsEditLayout.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/layouts/ClubDetailsEditLayout.kt
@@ -1,0 +1,195 @@
+package com.tpc.nudj.ui.layouts
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tpc.nudj.model.enums.ClubCategory
+import com.tpc.nudj.ui.components.DynamicTextFieldList
+import com.tpc.nudj.ui.components.NudjDescriptionTextField
+import com.tpc.nudj.ui.components.NudjDropDownMenu
+import com.tpc.nudj.ui.components.NudjImagePicker
+import com.tpc.nudj.ui.components.NudjTextField
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.screen.auth.createAndEditEvent.ClubFormUiState
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.ui.theme.NudjTheme
+
+@Composable
+fun ClubDetailsEditLayout(
+    uiState: ClubFormUiState,
+
+    onClubNameChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+
+    onCategorySelected: (ClubCategory) -> Unit,
+    onCategoryDropdownExpandedChange: (Boolean) -> Unit,
+
+    updateAchievement: (Int, String) -> Unit,
+    addAchievement: () -> Unit,
+    removeAchievement: (Int) -> Unit,
+
+    updateUpcomingEvent: (Int, String) -> Unit,
+    addUpcomingEvent: () -> Unit,
+    removeUpcomingEvent: (Int) -> Unit,
+
+    updatePastEvent: (Int, String) -> Unit,
+    addPastEvent: () -> Unit,
+    removePastEvent: (Int) -> Unit,
+
+    onLogoSelected: () -> Unit,
+    onCreateClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Column(
+            modifier=Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ){
+            NudjImagePicker(
+                imageUri = uiState.logoUri,
+                onClick = onLogoSelected,
+                modifier = Modifier.size(100.dp)
+            )
+            Text(
+                text="Logo",
+                style= MaterialTheme.typography.titleMedium,
+                color = LocalAppColors.current.onBackground
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        NudjTextField(
+            value = uiState.clubName,
+            onValueChange = onClubNameChange,
+            placeholder = "Club name",
+            modifier = Modifier.padding(horizontal = 32.dp)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text="Club Category",
+            style= MaterialTheme.typography.titleMedium,
+            color = LocalAppColors.current.onBackground
+            )
+        NudjDropDownMenu(
+            expanded = uiState.isCategoryDropdownExpanded,
+            selectedOption = uiState.category,
+            options = ClubCategory.entries,
+            placeholder = "Club Category",
+            trailingIcon = Icons.Default.KeyboardArrowDown,
+            onExpandedStateChange = onCategoryDropdownExpandedChange,
+            onSelectedOptionChange = onCategorySelected,
+            optionLabel = { it.categoryName }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        NudjDescriptionTextField(
+            value = uiState.description,
+            onValueChange = onDescriptionChange,
+            placeholder = "About club (optional)",
+            title="Club Description"
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        DynamicTextFieldList(
+            title = "Achievements",
+            items = uiState.achievements,
+            placeholder = "If any",
+            onValueChange = updateAchievement,
+            onAddClick = addAchievement,
+            onDeleteClick = removeAchievement
+        )
+
+        DynamicTextFieldList(
+            title = "Upcoming Events",
+            items = uiState.upcomingEvents,
+            placeholder = "If any",
+            onValueChange = updateUpcomingEvent,
+            onAddClick = addUpcomingEvent,
+            onDeleteClick = removeUpcomingEvent
+        )
+
+        DynamicTextFieldList(
+            title = "Past Events",
+            items = uiState.pastEvents,
+            placeholder = "If any",
+            onValueChange = updatePastEvent,
+            onAddClick = addPastEvent,
+            onDeleteClick = removePastEvent
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+        PrimaryButton(
+            text = "Create",
+            onClick = onCreateClick,
+            modifier=Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true , uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun ClubDetailsEditLayoutPreview() {
+    NudjTheme {
+        ClubDetailsEditLayout(
+            uiState = ClubFormUiState(
+                clubName = "The Programming Club",
+                category = ClubCategory.TECHNICAL,
+                description = "Official Coding Club of IIITDMJ",
+                achievements = listOf(
+                    "Organised Central India's largest Hackathon"
+                ),
+                upcomingEvents = listOf(
+                    "CodeRumble",
+                    "Lockouts"
+                ),
+                pastEvents = listOf(
+                    "Hackbyte"
+                ),
+                isCategoryDropdownExpanded = false
+            ),
+
+            onClubNameChange = {},
+            onDescriptionChange = {},
+
+            onCategorySelected = {},
+            onCategoryDropdownExpandedChange = {},
+
+            updateAchievement = { _, _ -> },
+            addAchievement = {},
+            removeAchievement = {},
+
+            updateUpcomingEvent = { _, _ -> },
+            addUpcomingEvent = {},
+            removeUpcomingEvent = {},
+
+            updatePastEvent = { _, _ -> },
+            addPastEvent = {},
+            removePastEvent = {},
+
+            onLogoSelected = {},
+            onCreateClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/layouts/GeneralEventDetailsLayout.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/layouts/GeneralEventDetailsLayout.kt
@@ -1,0 +1,272 @@
+package com.tpc.nudj.ui.layouts
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tpc.nudj.ui.components.DynamicTextFieldList
+import com.tpc.nudj.ui.components.NudjDescriptionTextField
+import com.tpc.nudj.ui.components.NudjDropDownMenu
+import com.tpc.nudj.ui.components.NudjImagePicker
+import com.tpc.nudj.ui.components.NudjTextField
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.screen.auth.createAndEditEvent.EventFormUiState
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.ui.theme.NudjTheme
+
+@Composable
+fun EventDetailsEditLayout(
+    uiState: EventFormUiState,
+    onLogoClick: () -> Unit,
+    onBannerClick: () -> Unit,
+    onPhotoClick: (Int) -> Unit,
+    onEventNameChange: (String) -> Unit,
+    onDateClick: () -> Unit,
+    onTimeClick: () -> Unit,
+    onVenueChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onYearSelected: (Int) -> Unit,
+    onYearDropdownExpandedChange: (Boolean) -> Unit,
+    onPastEventValueChange: (Int, String) -> Unit,
+    onAddPastEvent: () -> Unit,
+    onDeletePastEvent: (Int) -> Unit,
+    onCreateClick: () -> Unit,
+){
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ){
+        Column(
+            modifier=Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            NudjImagePicker(
+                imageUri = uiState.logoUri,
+                onClick = onLogoClick,
+                modifier = Modifier.size(100.dp)
+            )
+            Text(
+                text="Logo",
+                style= MaterialTheme.typography.titleMedium,
+                color = LocalAppColors.current.onBackground
+            )
+        }
+
+        Spacer(modifier=Modifier.height(12.dp))
+
+        NudjTextField(
+            value = uiState.eventName,
+            onValueChange = onEventNameChange,
+            placeholder = "Event Name",
+            modifier = Modifier.padding(horizontal=32.dp)
+        )
+
+        Spacer(modifier=Modifier.height(12.dp))
+
+        Column {
+            Text(
+                text="Event Banner",
+                style= MaterialTheme.typography.titleMedium,
+                color = LocalAppColors.current.onBackground
+                )
+            NudjImagePicker(
+                imageUri = uiState.bannerUri,
+                onClick = onBannerClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp),
+                shape = RoundedCornerShape(12.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier= Modifier.fillMaxWidth()
+        ) {
+            Column(modifier=Modifier.weight(1f)){
+                Text(
+                    text="Event Date",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = LocalAppColors.current.onBackground
+                )
+                NudjTextField(
+                    value = uiState.eventDate,
+                    onValueChange = {},
+                    placeholder = "Date",
+                    readOnly = true,
+                    trailingIcon = {
+                        IconButton(
+                            onClick = onDateClick
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.KeyboardArrowDown,
+                                contentDescription = null
+                            )
+                        }
+                    }
+                )
+            }
+
+            Spacer(modifier = Modifier.width(10.dp))
+
+            Column(modifier=Modifier.weight(1f)){
+                Text(
+                    text="Event Time",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = LocalAppColors.current.onBackground
+                    )
+                NudjTextField(
+                    value = uiState.eventTime,
+                    onValueChange = {},
+                    placeholder = "Time",
+                    readOnly = true,
+                    trailingIcon = {
+                        IconButton(
+                            onClick = onTimeClick
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.KeyboardArrowDown,
+                                contentDescription = null
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        Spacer(modifier=Modifier.height(12.dp))
+
+        Text(
+            text="Event Venue",
+            style = MaterialTheme.typography.titleMedium,
+            color = LocalAppColors.current.onBackground
+            )
+        NudjTextField(
+            value = uiState.venue,
+            onValueChange = onVenueChange,
+            placeholder = "Eg: Auditorium"
+        )
+
+        Spacer(modifier=Modifier.height(12.dp))
+
+        NudjDescriptionTextField(
+            value = uiState.description,
+            onValueChange = onDescriptionChange,
+            placeholder = "About event (optional)",
+            title = "Event Description"
+        )
+
+        Spacer(modifier=Modifier.height(12.dp))
+
+        DynamicTextFieldList(
+            title = "Past Events",
+            items = uiState.pastEvents,
+            placeholder = "If any",
+            onValueChange = onPastEventValueChange,
+            onAddClick = onAddPastEvent,
+            onDeleteClick = onDeletePastEvent
+        )
+
+        Text(text="Add Event Photos",
+            style= MaterialTheme.typography.titleMedium,
+            color = LocalAppColors.current.onBackground
+            )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+
+            uiState.photoUris.forEachIndexed { index, uri ->
+
+                NudjImagePicker(
+                    imageUri = uri,
+                    onClick = {
+                        onPhotoClick(index)
+                    },
+                    modifier = Modifier.size(75.dp).weight(1f),
+                    shape = RoundedCornerShape(12.dp)
+                )
+            }
+        }
+
+        Spacer(modifier=Modifier.height(12.dp))
+
+        Text(
+            text="Select the years it's applicable to ",
+            style= MaterialTheme.typography.titleMedium,
+            color = LocalAppColors.current.onBackground
+            )
+        NudjDropDownMenu(
+            selectedOption = uiState.selectedYear,
+            options = listOf(1, 2, 3, 4),
+            expanded = uiState.isYearDropdownExpanded,
+            onExpandedStateChange = onYearDropdownExpandedChange,
+            onSelectedOptionChange = onYearSelected,
+            placeholder = "Which year?",
+            trailingIcon = Icons.Default.KeyboardArrowDown
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        PrimaryButton(
+            text = "Create",
+            onClick = onCreateClick,
+            modifier=Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true , uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun EventDetailsEditLayoutPreview() {
+    NudjTheme {
+        EventDetailsEditLayout(
+            uiState = EventFormUiState(
+                eventName = "Event Name",
+                eventDate = "25 Jul 2026",
+                eventTime = "6:30 PM",
+                venue = "Event Venue",
+                description = "Join us for this great event",
+                pastEvents = listOf(
+                    "Workshop",
+                    "Camp"
+                ),
+                selectedYear = 2
+            ),
+            onLogoClick = {},
+            onBannerClick = {},
+            onPhotoClick = {},
+            onEventNameChange = {},
+            onVenueChange = {},
+            onDescriptionChange = {},
+            onYearSelected = {},
+            onYearDropdownExpandedChange = {},
+            onPastEventValueChange = { _, _ -> },
+            onAddPastEvent = {},
+            onDeletePastEvent = {},
+            onCreateClick = {},
+            onDateClick = {},
+            onTimeClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/ClubFormUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/ClubFormUiState.kt
@@ -1,0 +1,15 @@
+package com.tpc.nudj.ui.screen.auth.createAndEditEvent
+
+import android.net.Uri
+import com.tpc.nudj.model.enums.ClubCategory
+
+data class ClubFormUiState (
+    val logoUri: Uri? = null,
+    val clubName: String = "",
+    val category: ClubCategory? = null,
+    val description: String = "",
+    val achievements: List<String> = listOf(""),
+    val upcomingEvents: List<String> = listOf(""),
+    val pastEvents: List<String> = listOf(""),
+    val isCategoryDropdownExpanded: Boolean = false,
+)

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/CreateScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/CreateScreen.kt
@@ -1,0 +1,240 @@
+package com.tpc.nudj.ui.screen.auth.createAndEditEvent
+
+import java.util.Calendar
+import android.app.TimePickerDialog
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import android.app.DatePickerDialog
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.tpc.nudj.model.enums.FormType
+import com.tpc.nudj.model.enums.ImagePickerType
+import com.tpc.nudj.ui.components.NudjLogo
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.components.SecondaryButton
+import com.tpc.nudj.ui.layouts.ClubDetailsEditLayout
+import com.tpc.nudj.ui.layouts.EventDetailsEditLayout
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.viewmodels.auth.createAndEditEvent.ClubFormViewModel
+import com.tpc.nudj.viewmodels.auth.createAndEditEvent.CreateViewModel
+import com.tpc.nudj.viewmodels.auth.createAndEditEvent.EventFormViewModel
+import java.util.Locale
+
+@Composable
+fun CreateScreen(
+    createViewModel: CreateViewModel = hiltViewModel(),
+    clubFormViewModel: ClubFormViewModel = hiltViewModel(),
+    eventFormViewModel: EventFormViewModel = hiltViewModel()
+) {
+    val selectedForm by createViewModel.selectedForm.collectAsState()
+    val clubUiState by clubFormViewModel.clubFormUiState.collectAsState()
+    val eventUiState by eventFormViewModel.eventFormUiState.collectAsState()
+    val context = LocalContext.current
+    val calendar = Calendar.getInstance()
+    var currentImagePicker by remember {
+        mutableStateOf<ImagePickerType?>(null)
+    }
+    val imagePickerLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.GetContent()
+        ) { uri ->
+            uri ?: return@rememberLauncherForActivityResult
+            when (currentImagePicker) {
+                ImagePickerType.CLUB_LOGO ->
+                    clubFormViewModel.onLogoSelected(uri)
+                ImagePickerType.EVENT_LOGO ->
+                    eventFormViewModel.onLogoSelected(uri)
+                ImagePickerType.EVENT_BANNER ->
+                    eventFormViewModel.onBannerSelected(uri)
+                ImagePickerType.EVENT_PHOTO_1 ->
+                    eventFormViewModel.onPhotoSelected(0, uri)
+                ImagePickerType.EVENT_PHOTO_2 ->
+                    eventFormViewModel.onPhotoSelected(1, uri)
+                ImagePickerType.EVENT_PHOTO_3 ->
+                    eventFormViewModel.onPhotoSelected(2, uri)
+                null -> {}
+            }
+        }
+    Scaffold(
+        containerColor = LocalAppColors.current.background
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            NudjLogo()
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (selectedForm == FormType.GENERAL_EVENT) {
+                    PrimaryButton(
+                        text = "General Event",
+                        onClick = {
+                            createViewModel.onFormSelected(FormType.GENERAL_EVENT)
+                        },
+                        modifier = Modifier.weight(7f),
+                        hasBorder = true
+                    )
+                } else {
+                    SecondaryButton(
+                        text = "General Event",
+                        onClick = {
+                            createViewModel.onFormSelected(FormType.GENERAL_EVENT)
+                        },
+                        modifier = Modifier.weight(7f)
+                    )
+                }
+                if (selectedForm == FormType.CLUB) {
+                    PrimaryButton(
+                        text = "Club",
+                        onClick = {
+                            createViewModel.onFormSelected(FormType.CLUB)
+                        },
+                        modifier = Modifier.weight(3f),
+                        hasBorder = true
+                    )
+                } else {
+                    SecondaryButton(
+                        text = "Club",
+                        onClick = {
+                            createViewModel.onFormSelected(FormType.CLUB)
+                        },
+                        modifier = Modifier.weight(3f)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            when (selectedForm) {
+                FormType.CLUB -> {
+                    ClubDetailsEditLayout(
+                        uiState = clubUiState,
+
+                        onClubNameChange = clubFormViewModel::onClubNameChange,
+                        onDescriptionChange = clubFormViewModel::onDescriptionChange,
+
+                        onCategorySelected = clubFormViewModel::onCategorySelected,
+                        onCategoryDropdownExpandedChange = clubFormViewModel::onCategoryDropdownExpandedChange,
+
+                        updateAchievement = clubFormViewModel::updateAchievement,
+                        addAchievement = clubFormViewModel::addAchievement,
+                        removeAchievement = clubFormViewModel::removeAchievement,
+
+                        updateUpcomingEvent = clubFormViewModel::updateUpcomingEvent,
+                        addUpcomingEvent = clubFormViewModel::addUpcomingEvent,
+                        removeUpcomingEvent = clubFormViewModel::removeUpcomingEvent,
+
+                        updatePastEvent = clubFormViewModel::updatePastEvent,
+                        addPastEvent = clubFormViewModel::addPastEvent,
+                        removePastEvent = clubFormViewModel::removePastEvent,
+
+                        onLogoSelected = {
+                            currentImagePicker = ImagePickerType.CLUB_LOGO
+                            imagePickerLauncher.launch("image/*")
+                        },
+
+                        onCreateClick = {
+                        }
+                    )
+                }
+                FormType.GENERAL_EVENT -> {
+                    EventDetailsEditLayout(
+                        uiState = eventUiState,
+
+                        onLogoClick = {
+                                currentImagePicker = ImagePickerType.EVENT_LOGO
+                                imagePickerLauncher.launch("image/*")
+                        },
+
+                        onBannerClick = {
+                            currentImagePicker = ImagePickerType.EVENT_BANNER
+                            imagePickerLauncher.launch("image/*")
+                        },
+
+                        onPhotoClick = {index ->
+                            currentImagePicker = when (index) {
+                                0 -> ImagePickerType.EVENT_PHOTO_1
+                                1 -> ImagePickerType.EVENT_PHOTO_2
+                                else -> ImagePickerType.EVENT_PHOTO_3
+                            }
+                            imagePickerLauncher.launch("image/*")
+                        },
+
+                        onEventNameChange = eventFormViewModel::onEventNameChange,
+                        onVenueChange = eventFormViewModel::onVenueChange,
+                        onDescriptionChange = eventFormViewModel::onDescriptionChange,
+
+                        onDateClick = {
+                            DatePickerDialog(
+                                context,
+                                { _, year, month, dayOfMonth ->
+                                    val selectedDate = "$dayOfMonth/${month + 1}/$year"
+                                    eventFormViewModel.onEventDateChange(selectedDate)
+                                },
+                                calendar.get(Calendar.YEAR),
+                                calendar.get(Calendar.MONTH),
+                                calendar.get(Calendar.DAY_OF_MONTH)
+                            ).show()
+                        },
+                        onTimeClick = {
+                            TimePickerDialog(
+                                context,
+                                { _, hourOfDay, minute ->
+                                    val selectedTime = String.format(
+                                        Locale.getDefault(),
+                                        "%02d:%02d",
+                                        hourOfDay,
+                                        minute
+                                    )
+                                    eventFormViewModel.onEventTimeChange(selectedTime)
+                                },
+                                calendar.get(Calendar.HOUR_OF_DAY),
+                                calendar.get(Calendar.MINUTE),
+                                true
+                            ).show()
+                        },
+
+                        onYearSelected = eventFormViewModel::onYearSelected,
+                        onYearDropdownExpandedChange = eventFormViewModel::onYearDropdownExpandedChange,
+
+                        onPastEventValueChange = eventFormViewModel::updatePastEvent,
+                        onAddPastEvent = eventFormViewModel::addPastEvent,
+                        onDeletePastEvent = eventFormViewModel::removePastEvent,
+
+                        onCreateClick = {
+
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/EditScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/EditScreen.kt
@@ -1,0 +1,189 @@
+package com.tpc.nudj.ui.screen.auth.createAndEditEvent
+
+import java.util.Calendar
+import android.app.TimePickerDialog
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import android.app.DatePickerDialog
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.tpc.nudj.model.enums.FormType
+import com.tpc.nudj.model.enums.ImagePickerType
+import com.tpc.nudj.ui.components.NudjTopAppBar
+import com.tpc.nudj.ui.layouts.ClubDetailsEditLayout
+import com.tpc.nudj.ui.layouts.EventDetailsEditLayout
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.viewmodels.auth.createAndEditEvent.ClubFormViewModel
+import com.tpc.nudj.viewmodels.auth.createAndEditEvent.EventFormViewModel
+import java.util.Locale
+
+@Composable
+fun EditScreen(
+    formType: FormType,
+    clubFormViewModel: ClubFormViewModel = hiltViewModel(),
+    eventFormViewModel: EventFormViewModel = hiltViewModel()
+) {
+    val clubUiState by clubFormViewModel.clubFormUiState.collectAsState()
+    val eventUiState by eventFormViewModel.eventFormUiState.collectAsState()
+    val context = LocalContext.current
+    val calendar = Calendar.getInstance()
+    var currentImagePicker by remember {
+        mutableStateOf<ImagePickerType?>(null)
+    }
+    val imagePickerLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.GetContent()
+        ) { uri ->
+            uri ?: return@rememberLauncherForActivityResult
+            when (currentImagePicker) {
+                ImagePickerType.CLUB_LOGO ->
+                    clubFormViewModel.onLogoSelected(uri)
+                ImagePickerType.EVENT_LOGO ->
+                    eventFormViewModel.onLogoSelected(uri)
+                ImagePickerType.EVENT_BANNER ->
+                    eventFormViewModel.onBannerSelected(uri)
+                ImagePickerType.EVENT_PHOTO_1 ->
+                    eventFormViewModel.onPhotoSelected(0, uri)
+                ImagePickerType.EVENT_PHOTO_2 ->
+                    eventFormViewModel.onPhotoSelected(1, uri)
+                ImagePickerType.EVENT_PHOTO_3 ->
+                    eventFormViewModel.onPhotoSelected(2, uri)
+                null -> {}
+            }
+        }
+    Scaffold(
+        containerColor = LocalAppColors.current.background,
+        topBar = {
+            NudjTopAppBar(
+                onBackClick = {}
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            when (formType) {
+                FormType.CLUB -> {
+                    ClubDetailsEditLayout(
+                        uiState = clubUiState,
+
+                        onClubNameChange = clubFormViewModel::onClubNameChange,
+                        onDescriptionChange = clubFormViewModel::onDescriptionChange,
+
+                        onCategorySelected = clubFormViewModel::onCategorySelected,
+                        onCategoryDropdownExpandedChange = clubFormViewModel::onCategoryDropdownExpandedChange,
+
+                        updateAchievement = clubFormViewModel::updateAchievement,
+                        addAchievement = clubFormViewModel::addAchievement,
+                        removeAchievement = clubFormViewModel::removeAchievement,
+
+                        updateUpcomingEvent = clubFormViewModel::updateUpcomingEvent,
+                        addUpcomingEvent = clubFormViewModel::addUpcomingEvent,
+                        removeUpcomingEvent = clubFormViewModel::removeUpcomingEvent,
+
+                        updatePastEvent = clubFormViewModel::updatePastEvent,
+                        addPastEvent = clubFormViewModel::addPastEvent,
+                        removePastEvent = clubFormViewModel::removePastEvent,
+
+                        onLogoSelected = {
+                            currentImagePicker = ImagePickerType.CLUB_LOGO
+                            imagePickerLauncher.launch("image/*")
+                        },
+
+                        onCreateClick = {
+
+                        }
+                    )
+                }
+
+                FormType.GENERAL_EVENT -> {
+                    EventDetailsEditLayout(
+                        uiState = eventUiState,
+
+                        onLogoClick = {
+                            currentImagePicker = ImagePickerType.EVENT_LOGO
+                            imagePickerLauncher.launch("image/*")
+                        },
+
+                        onBannerClick = {
+                            currentImagePicker = ImagePickerType.EVENT_BANNER
+                            imagePickerLauncher.launch("image/*")
+                        },
+
+                        onPhotoClick = { index ->
+                            currentImagePicker = when (index) {
+                                0 -> ImagePickerType.EVENT_PHOTO_1
+                                1 -> ImagePickerType.EVENT_PHOTO_2
+                                else -> ImagePickerType.EVENT_PHOTO_3
+                            }
+                            imagePickerLauncher.launch("image/*")
+                        },
+
+                        onEventNameChange = eventFormViewModel::onEventNameChange,
+                        onVenueChange = eventFormViewModel::onVenueChange,
+                        onDescriptionChange = eventFormViewModel::onDescriptionChange,
+
+                        onDateClick = {
+                            DatePickerDialog(
+                                context,
+                                { _, year, month, dayOfMonth ->
+                                    val selectedDate = "$dayOfMonth/${month + 1}/$year"
+                                    eventFormViewModel.onEventDateChange(selectedDate)
+                                },
+                                calendar.get(Calendar.YEAR),
+                                calendar.get(Calendar.MONTH),
+                                calendar.get(Calendar.DAY_OF_MONTH)
+                            ).show()
+                        },
+
+                        onTimeClick = {
+                            TimePickerDialog(
+                                context,
+                                { _, hourOfDay, minute ->
+                                    val selectedTime = String.format(
+                                        Locale.getDefault(),
+                                        "%02d:%02d",
+                                        hourOfDay,
+                                        minute
+                                    )
+                                    eventFormViewModel.onEventTimeChange(selectedTime)
+                                },
+                                calendar.get(Calendar.HOUR_OF_DAY),
+                                calendar.get(Calendar.MINUTE),
+                                true
+                            ).show()
+                        },
+
+                        onYearSelected = eventFormViewModel::onYearSelected,
+                        onYearDropdownExpandedChange = eventFormViewModel::onYearDropdownExpandedChange,
+
+                        onPastEventValueChange = eventFormViewModel::updatePastEvent,
+                        onAddPastEvent = eventFormViewModel::addPastEvent,
+                        onDeletePastEvent = eventFormViewModel::removePastEvent,
+
+                        onCreateClick = {
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/EventFormUiState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screen/auth/createAndEditEvent/EventFormUiState.kt
@@ -1,0 +1,17 @@
+package com.tpc.nudj.ui.screen.auth.createAndEditEvent
+
+import android.net.Uri
+
+data class EventFormUiState(
+    val logoUri: Uri? = null,
+    val bannerUri: Uri? = null,
+    val eventName: String = "",
+    val eventDate: String = "",
+    val eventTime: String = "",
+    val venue: String = "",
+    val description: String = "",
+    val pastEvents: List<String> = listOf(""),
+    val photoUris: List<Uri?> = List(3) { null },
+    val selectedYear: Int? = null,
+    val isYearDropdownExpanded: Boolean = false
+)

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/createAndEditEvent/ClubFormViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/createAndEditEvent/ClubFormViewModel.kt
@@ -1,0 +1,115 @@
+package com.tpc.nudj.viewmodels.auth.createAndEditEvent
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import com.tpc.nudj.model.enums.ClubCategory
+import com.tpc.nudj.ui.screen.auth.createAndEditEvent.ClubFormUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class ClubFormViewModel @Inject constructor() : ViewModel() {
+    private val _clubFormUiState = MutableStateFlow(ClubFormUiState())
+    val clubFormUiState: StateFlow<ClubFormUiState> = _clubFormUiState.asStateFlow()
+
+    fun onLogoSelected(uri: Uri?) {
+        _clubFormUiState.update {
+            it.copy(logoUri = uri)
+        }
+    }
+    fun onClubNameChange(newClubName: String){
+        _clubFormUiState.update {
+            it.copy(clubName = newClubName)
+        }
+    }
+    fun onCategorySelected(category: ClubCategory) {
+        _clubFormUiState.update {
+            it.copy(category = category, isCategoryDropdownExpanded = false)
+        }
+    }
+    fun onCategoryDropdownExpandedChange(isExpanded: Boolean) {
+        _clubFormUiState.update {
+            it.copy(isCategoryDropdownExpanded = isExpanded)
+        }
+    }
+    fun onDescriptionChange(newDescription: String){
+        _clubFormUiState.update {
+            it.copy(description = newDescription)
+        }
+    }
+    fun updateAchievement(index: Int, value: String) {
+        _clubFormUiState.update {
+            val list = it.achievements.toMutableList()
+            list[index] = value
+            it.copy(achievements = list)
+        }
+    }
+    fun addAchievement() {
+        _clubFormUiState.update {
+            it.copy(
+                achievements = it.achievements + ""
+            )
+        }
+    }
+    fun removeAchievement(index: Int) {
+        _clubFormUiState.update {
+            val list = it.achievements.toMutableList()
+            if (index in list.indices) {
+                list.removeAt(index)
+            }
+            it.copy(achievements = list)
+        }
+    }
+
+    fun updateUpcomingEvent(index: Int, value: String) {
+        _clubFormUiState.update {
+            val list = it.upcomingEvents.toMutableList()
+            list[index] = value
+            it.copy(upcomingEvents = list)
+        }
+    }
+    fun addUpcomingEvent() {
+        _clubFormUiState.update {
+            it.copy(
+                upcomingEvents = it.upcomingEvents + ""
+            )
+        }
+    }
+    fun removeUpcomingEvent(index: Int) {
+        _clubFormUiState.update {
+            val list = it.upcomingEvents.toMutableList()
+            if (index in list.indices) {
+                list.removeAt(index)
+            }
+            it.copy(upcomingEvents = list)
+        }
+    }
+
+    fun updatePastEvent(index: Int, value: String) {
+        _clubFormUiState.update {
+            val list = it.pastEvents.toMutableList()
+            list[index] = value
+            it.copy(pastEvents = list)
+        }
+    }
+    fun addPastEvent() {
+        _clubFormUiState.update {
+            it.copy(
+                pastEvents = it.pastEvents + ""
+            )
+        }
+    }
+    fun removePastEvent(index: Int) {
+        _clubFormUiState.update {
+            val list = it.pastEvents.toMutableList()
+            if (index in list.indices) {
+                list.removeAt(index)
+            }
+            it.copy(pastEvents = list)
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/createAndEditEvent/CreateViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/createAndEditEvent/CreateViewModel.kt
@@ -1,0 +1,19 @@
+package com.tpc.nudj.viewmodels.auth.createAndEditEvent
+
+import androidx.lifecycle.ViewModel
+import com.tpc.nudj.model.enums.FormType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class CreateViewModel @Inject constructor() : ViewModel() {
+
+    private val _selectedForm = MutableStateFlow(FormType.CLUB)
+    val selectedForm = _selectedForm.asStateFlow()
+
+    fun onFormSelected(formType: FormType) {
+        _selectedForm.value = formType
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/viewmodels/auth/createAndEditEvent/EventFormViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/viewmodels/auth/createAndEditEvent/EventFormViewModel.kt
@@ -1,0 +1,104 @@
+package com.tpc.nudj.viewmodels.auth.createAndEditEvent
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import com.tpc.nudj.ui.screen.auth.createAndEditEvent.EventFormUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class EventFormViewModel @Inject constructor() : ViewModel() {
+    private val _eventFormUiState = MutableStateFlow(EventFormUiState())
+    val eventFormUiState = _eventFormUiState.asStateFlow()
+
+    fun onLogoSelected(uri: Uri?) {
+        _eventFormUiState.update {
+            it.copy(logoUri = uri)
+        }
+    }
+
+    fun onBannerSelected(uri: Uri?) {
+        _eventFormUiState.update {
+            it.copy(bannerUri = uri)
+        }
+    }
+
+    fun onEventNameChange(name: String) {
+        _eventFormUiState.update {
+            it.copy(eventName = name)
+        }
+    }
+
+    fun onEventDateChange(date: String) {
+        _eventFormUiState.update {
+            it.copy(eventDate = date)
+        }
+    }
+
+    fun onEventTimeChange(time: String) {
+        _eventFormUiState.update {
+            it.copy(eventTime = time)
+        }
+    }
+
+    fun onVenueChange(venue: String) {
+        _eventFormUiState.update {
+            it.copy(venue = venue)
+        }
+    }
+
+    fun onDescriptionChange(description: String) {
+        _eventFormUiState.update {
+            it.copy(description = description)
+        }
+    }
+
+    fun updatePastEvent(index: Int, value: String) {
+        _eventFormUiState.update {
+            val list = it.pastEvents.toMutableList()
+            list[index] = value
+            it.copy(pastEvents = list)
+        }
+    }
+
+    fun addPastEvent() {
+        _eventFormUiState.update {
+            it.copy(
+                pastEvents = it.pastEvents + ""
+            )
+        }
+    }
+
+    fun removePastEvent(index: Int) {
+        _eventFormUiState.update {
+            val list = it.pastEvents.toMutableList()
+            if(index in list.indices){
+                list.removeAt(index)
+            }
+            it.copy(pastEvents = list)
+        }
+    }
+
+    fun onPhotoSelected(index: Int, uri: Uri?) {
+        _eventFormUiState.update {
+            val photos = it.photoUris.toMutableList()
+            photos[index] = uri
+            it.copy(photoUris = photos)
+        }
+    }
+
+    fun onYearSelected(year: Int) {
+        _eventFormUiState.update {
+            it.copy(selectedYear = year)
+        }
+    }
+
+    fun onYearDropdownExpandedChange(expanded: Boolean) {
+        _eventFormUiState.update {
+            it.copy(isYearDropdownExpanded = expanded)
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request – Nudj Contribution

Thank you for contributing to Nudj! Please fill out this PR template completely so we can review your work effectively.

---

## 🔧 What does this PR do?

> Briefly summarize your changes. Focus on what you did, not how.

- Created reusable layouts for club and general event forms.
- Implemented Create and Edit screens using the shared layouts.
- Added a reusable image picker component.
- Added a reusable dynamic text field list component.
- Implemented form state management using the MVVM architecture with ViewModels and StateFlow.
- Integrated date and time pickers for event forms.
- Added Coil Compose dependency for image loading.

---

## 🧩 Related Issue

> Mention the issue this PR resolves. If not assigned officially, your PR may not be merged.

Closes: #40 

---

## 📸 Screenshots / UI Demo (If applicable)

> Add screenshots or screen recordings to showcase any visual/UI changes.

---

https://github.com/user-attachments/assets/dbad94b6-bece-4df7-a6a2-db11264645ff

https://github.com/user-attachments/assets/df8967ff-55c6-4985-8bde-ae0a0edd3a15

https://github.com/user-attachments/assets/0cdf2d2a-d8d5-4f2d-a17a-419e4057a81a


## ✅ Checklist

- [x] My code follows the project's style and structure
- [x] I’ve tested my changes locally
- [x] I’ve not committed any files directly to `main`
- [x] I’ve commented my approach in the linked issue
- [x] My commit messages are clean and meaningful
- [x] This PR focuses on one clear task/feature only

---

## 🧠 Brief Explanation of Approach

> Describe your thought process or logic briefly – useful for reviewers to understand your implementation.

---
I created reusable layouts for club and general event forms, which are shared by both the Create and Edit screens to avoid code duplication. I also created reusable UI components, such as the dynamic text field list and image picker, so they can be reused wherever required within the layouts. For switching between the club and event forms in the Create screen, I used a FormType enum to determine which layout to display. For image selection, instead of maintaining separate activity result launchers for each image field, I reused a single launcher and used an ImagePickerType enum to identify the target image, keeping the image picker logic centralized and reducing repetitive code. Form state is managed using the MVVM architecture with ViewModel and StateFlow, ensuring a clear separation between the UI and business logic.

## 📢 Additional Notes (Optional)

> Anything the reviewer should be aware of? (Edge cases, known issues, etc.)

---
